### PR TITLE
Enable / Allow: BTC.b/Boosted Aave V3 USD on Avalanche

### DIFF
--- a/tasks/20230320-weighted-pool-v4/output/avalanche.json
+++ b/tasks/20230320-weighted-pool-v4/output/avalanche.json
@@ -1,4 +1,3 @@
 {
-  "WeightedPoolFactory": "0x230a59F4d9ADc147480f03B0D3fFfeCd56c3289a",
-  "MockWeightedPool": "0xb2b5B452d53401391155EA48C4451f6E9b0dD058"
+  "Weighted.Allowlist": "0x3f1A2C4a3a751f6626bD90eF16e104f0772d4d6B",
 }


### PR DESCRIPTION
I am unable to figure out how to to enable this new weighted pool that was created on the Balancer app frontend. Any help would be very much appreciated, thank you!

Pool name: BTC.b/Boosted Aave V3 USD
Pool symbol: 50BTC.b-50bb-a-USD
Pool type: Weighted
Swap fees: 0.5% (this may be edited via Governance)
Pool Manager: None
Pool Owner: Delegate owner
Contract address: 0x3f1A2C4a3a751f6626bD90eF16e104f0772d4d6B
Creation date: 04 August 2023
