### PR TITLE
fix: add gnosis networks to externally-used .supported-networks file

### DIFF
--- a/addresses/.supported-networks.json
+++ b/addresses/.supported-networks.json
@@ -15,6 +15,10 @@
     "chainId": 56,
     "block-explorer": "https://bscscan.com"
   },
+  "gnosis": {
+    "chainId": 100,
+    "block-explorer": "https://gnosisscan.io"
+  },
   "goerli": {
     "chainId": 5,
     "block-explorer": "https://goerli.etherscan.io"


### PR DESCRIPTION
# Description

Add gnosis to .supported-networks.json file. This is not used in this repo, but supports external scripts and tooling.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

