### PR TITLE
Recover code for MockAvalancheRootGauge

### DIFF
--- a/src/helpers/contracts/MockAvalancheRootGauge.sol
+++ b/src/helpers/contracts/MockAvalancheRootGauge.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+/*
+This contract is part of the build-info for the 20230811-avalanche-root-gauge-factory-v2, but is no longer in the
+monorepo. We cannot actually include it here without introducing a dependency on liquidity-mining, but here is the
+source code for reference.
+
+import "../gauges/avalanche/AvalancheRootGauge.sol";
+
+contract MockAvalancheRootGauge is AvalancheRootGauge {
+    constructor(IMainnetBalancerMinter minter, ILayerZeroBALProxy lzBALProxy) AvalancheRootGauge(minter, lzBALProxy) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    /**
+     * @dev It would be very difficult to contrive a fork test that set the mintAmount to a precise value,
+     * so the bridge limits are best tested with a mock and unit tests.
+     * It must be payable to send ETH to pay for gas in the child chain.
+     * @param mintAmount Amount to be bridged
+     *
+    function bridge(uint256 mintAmount) external payable {
+        _postMintAction(mintAmount);
+    }
+} */

--- a/tasks/20230811-avalanche-root-gauge-factory-v2/test/task.fork.ts
+++ b/tasks/20230811-avalanche-root-gauge-factory-v2/test/task.fork.ts
@@ -337,6 +337,7 @@ describeForkTest('AvalancheRootGaugeFactory V2', 'mainnet', 17879200, function (
     sharedBeforeEach(async () => {
       const input = task.input() as AvalancheRootGaugeFactoryDeployment;
       // We need to set force to `true`.
+      // Source code for this Mock is in src/helpers/contracts
       mockGauge = await task.deploy('MockAvalancheRootGauge', [input.BalancerMinter, input.BALProxy], admin, true);
 
       // Fund mock gauge with BAL


### PR DESCRIPTION
# Description

Recover code for MockAvalancheRootGauge. Used to create build-info for 20230811-avalanche-root-gauge-factory-v2, then deleted from the monorepo. Ensure code is available here for reference (without introducing dependencies).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other - an "Other" if there ever was one!

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution
