### PR TITLE
Fix: duplicate entry in timelock authorizer settings (testnets).

### DIFF
--- a/tasks/20230522-timelock-authorizer/input/goerli.ts
+++ b/tasks/20230522-timelock-authorizer/input/goerli.ts
@@ -102,7 +102,7 @@ export const GrantDelays: DelayData[] = [
     newDelay: LONG_DELAY,
   },
   {
-    actionId: Vault.actionId('ProtocolFeesCollector', 'withdrawCollectedFees(address[],uint256[],address)'),
+    actionId: Vault.actionId('ProtocolFeesCollector', 'setFlashLoanFeePercentage(uint256)'),
     newDelay: LONG_DELAY,
   },
 ];
@@ -251,3 +251,14 @@ export const ExecuteDelays: DelayData[] = [
     newDelay: SHORT_DELAY,
   },
 ];
+
+// Checks
+
+const actionIds = [
+  ExecuteDelays.map((delayData) => delayData.actionId),
+  GrantDelays.map((delayData) => delayData.actionId),
+].flat();
+
+if (new Set(actionIds).size !== actionIds.length) {
+  throw new Error('Duplicate action ID found in configuration');
+}

--- a/tasks/20230522-timelock-authorizer/input/goerli.ts
+++ b/tasks/20230522-timelock-authorizer/input/goerli.ts
@@ -262,3 +262,12 @@ const actionIds = [
 if (new Set(actionIds).size !== actionIds.length) {
   throw new Error('Duplicate action ID found in configuration');
 }
+
+const delays = [
+  ExecuteDelays.map((delayData) => delayData.newDelay),
+  GrantDelays.map((delayData) => delayData.newDelay),
+].flat();
+
+if (delays.some((delay) => delay < SHORT_DELAY || delay > LONG_DELAY)) {
+  throw new Error('Delays outside expected bounds');
+}

--- a/tasks/20230522-timelock-authorizer/input/sepolia.ts
+++ b/tasks/20230522-timelock-authorizer/input/sepolia.ts
@@ -261,3 +261,12 @@ const actionIds = [
 if (new Set(actionIds).size !== actionIds.length) {
   throw new Error('Duplicate action ID found in configuration');
 }
+
+const delays = [
+  ExecuteDelays.map((delayData) => delayData.newDelay),
+  GrantDelays.map((delayData) => delayData.newDelay),
+].flat();
+
+if (delays.some((delay) => delay < SHORT_DELAY || delay > LONG_DELAY)) {
+  throw new Error('Delays outside expected bounds');
+}

--- a/tasks/20230522-timelock-authorizer/input/sepolia.ts
+++ b/tasks/20230522-timelock-authorizer/input/sepolia.ts
@@ -101,7 +101,7 @@ export const GrantDelays: DelayData[] = [
     newDelay: LONG_DELAY,
   },
   {
-    actionId: Vault.actionId('ProtocolFeesCollector', 'withdrawCollectedFees(address[],uint256[],address)'),
+    actionId: Vault.actionId('ProtocolFeesCollector', 'setFlashLoanFeePercentage(uint256)'),
     newDelay: LONG_DELAY,
   },
 ];
@@ -250,3 +250,14 @@ export const ExecuteDelays: DelayData[] = [
     newDelay: SHORT_DELAY,
   },
 ];
+
+// Checks
+
+const actionIds = [
+  ExecuteDelays.map((delayData) => delayData.actionId),
+  GrantDelays.map((delayData) => delayData.actionId),
+].flat();
+
+if (new Set(actionIds).size !== actionIds.length) {
+  throw new Error('Duplicate action ID found in configuration');
+}


### PR DESCRIPTION
# Description

While working on #89 I realized there was a duplicate entry in the config files.
While this is not a problem in practice (the delay is correctly configured on-chain, and in any case it can be changed), it'd be convenient to correct this for future deployments.

By modifying the input file, the verification will fail. Given that only testnets are involved, I'd just redeploy.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A