### PR TITLE
Verify splitcode pseudo-contracts are not executable

### DIFF
--- a/tasks/20211202-no-protocol-fee-lbp/test/task.fork.ts
+++ b/tasks/20211202-no-protocol-fee-lbp/test/task.fork.ts
@@ -1,6 +1,6 @@
 import hre from 'hardhat';
 import { expect } from 'chai';
-import { BigNumber, Contract } from 'ethers';
+import { BigNumber, Contract, ethers } from 'ethers';
 
 import { WeightedPoolEncoder } from '@helpers/models/pools/weighted/encoder';
 import { SwapKind } from '@helpers/models/types/types';
@@ -152,6 +152,23 @@ describeForkTest('NoProtocolFeeLiquidityBootstrappingPoolFactory', 'mainnet', 14
 
     // Weights are not exact due to being stored in fewer bits
     expect(await pool.getNormalizedWeights()).to.equalWithError(endWeights, 0.0001);
+  });
+
+  it('cannot execute the contract halves', async () => {
+    const { contractA, contractB } = await factory.getCreationCodeContracts();
+
+    const txA = {
+      to: contractA,
+      value: ethers.utils.parseEther('0.001'),
+    };
+
+    const txB = {
+      to: contractB,
+      value: ethers.utils.parseEther('0.001'),
+    };
+
+    await expect(owner.sendTransaction(txA)).to.be.reverted;
+    await expect(owner.sendTransaction(txB)).to.be.reverted;
   });
 
   it('authorized accounts can disable the factory', async () => {

--- a/tasks/20230320-weighted-pool-v4/test/task.fork.ts
+++ b/tasks/20230320-weighted-pool-v4/test/task.fork.ts
@@ -343,7 +343,7 @@ describeForkTest('WeightedPool V4', 'mainnet', 16870763, function () {
     await expect(owner.sendTransaction(txA)).to.be.reverted;
     await expect(owner.sendTransaction(txB)).to.be.reverted;
   });
-  
+
   describe('factory disable', () => {
     it('the factory can be disabled', async () => {
       await authorizer.connect(govMultisig).grantRole(await actionId(factory, 'disable'), govMultisig.address);

--- a/tasks/20230320-weighted-pool-v4/test/task.fork.ts
+++ b/tasks/20230320-weighted-pool-v4/test/task.fork.ts
@@ -1,6 +1,6 @@
 import hre from 'hardhat';
 import { expect } from 'chai';
-import { Contract } from 'ethers';
+import { Contract, ethers } from 'ethers';
 import { sharedBeforeEach } from '@helpers/sharedBeforeEach';
 import { BasePoolEncoder } from '@helpers/models/pools/utils/encoder';
 import { WeightedPoolEncoder } from '@helpers/models/pools/weighted/encoder';
@@ -327,6 +327,23 @@ describeForkTest('WeightedPool V4', 'mainnet', 16870763, function () {
     });
   });
 
+  it('cannot execute the contract halves', async () => {
+    const { contractA, contractB } = await factory.getCreationCodeContracts();
+
+    const txA = {
+      to: contractA,
+      value: ethers.utils.parseEther('0.001'),
+    };
+
+    const txB = {
+      to: contractB,
+      value: ethers.utils.parseEther('0.001'),
+    };
+
+    await expect(owner.sendTransaction(txA)).to.be.reverted;
+    await expect(owner.sendTransaction(txB)).to.be.reverted;
+  });
+  
   describe('factory disable', () => {
     it('the factory can be disabled', async () => {
       await authorizer.connect(govMultisig).grantRole(await actionId(factory, 'disable'), govMultisig.address);

--- a/tasks/20230411-managed-pool-v2/test/task.fork.ts
+++ b/tasks/20230411-managed-pool-v2/test/task.fork.ts
@@ -383,7 +383,7 @@ describeForkTest('ManagedPoolFactory', 'mainnet', 17033100, function () {
     await expect(owner.sendTransaction(txA)).to.be.reverted;
     await expect(owner.sendTransaction(txB)).to.be.reverted;
   });
-  
+
   describe('factory disable', () => {
     it('the factory can be disabled', async () => {
       await authorizer.connect(govMultisig).grantRole(await actionId(factory, 'disable'), govMultisig.address);

--- a/tasks/20230411-managed-pool-v2/test/task.fork.ts
+++ b/tasks/20230411-managed-pool-v2/test/task.fork.ts
@@ -1,6 +1,6 @@
 import hre from 'hardhat';
 import { expect } from 'chai';
-import { Contract } from 'ethers';
+import { Contract, ethers } from 'ethers';
 import { BasePoolEncoder } from '@helpers/models/pools/utils/encoder';
 import { WeightedPoolEncoder } from '@helpers/models/pools/weighted/encoder';
 import { SwapKind } from '@helpers/models/types/types';
@@ -367,6 +367,23 @@ describeForkTest('ManagedPoolFactory', 'mainnet', 17033100, function () {
     });
   });
 
+  it('cannot execute the contract halves', async () => {
+    const { contractA, contractB } = await factory.getCreationCodeContracts();
+
+    const txA = {
+      to: contractA,
+      value: ethers.utils.parseEther('0.001'),
+    };
+
+    const txB = {
+      to: contractB,
+      value: ethers.utils.parseEther('0.001'),
+    };
+
+    await expect(owner.sendTransaction(txA)).to.be.reverted;
+    await expect(owner.sendTransaction(txB)).to.be.reverted;
+  });
+  
   describe('factory disable', () => {
     it('the factory can be disabled', async () => {
       await authorizer.connect(govMultisig).grantRole(await actionId(factory, 'disable'), govMultisig.address);

--- a/tasks/20230711-composable-stable-pool-v5/test/test.fork.ts
+++ b/tasks/20230711-composable-stable-pool-v5/test/test.fork.ts
@@ -1,6 +1,6 @@
 import hre from 'hardhat';
 import { expect } from 'chai';
-import { BigNumber, Contract } from 'ethers';
+import { BigNumber, Contract, ethers } from 'ethers';
 
 import * as expectEvent from '@helpers/expectEvent';
 import { describeForkTest } from '@src';
@@ -293,7 +293,7 @@ describeForkTest('ComposableStablePool V5', 'mainnet', 17663500, function () {
       });
     });
   });
-
+  
   describe('read-only reentrancy protection', () => {
     let pool: Contract;
     let poolId: string;
@@ -445,6 +445,23 @@ describeForkTest('ComposableStablePool V5', 'mainnet', 17663500, function () {
     });
   });
 
+  it('cannot execute the contract halves', async () => {
+    const { contractA, contractB } = await factory.getCreationCodeContracts();
+
+    const txA = {
+      to: contractA,
+      value: ethers.utils.parseEther('0.001'),
+    };
+
+    const txB = {
+      to: contractB,
+      value: ethers.utils.parseEther('0.001'),
+    };
+
+    await expect(owner.sendTransaction(txA)).to.be.reverted;
+    await expect(owner.sendTransaction(txB)).to.be.reverted;
+  });
+  
   describe('factory disable', () => {
     it('the factory can be disabled', async () => {
       await authorizer.connect(govMultisig).grantRole(await actionId(factory, 'disable'), govMultisig.address);

--- a/tasks/20230711-composable-stable-pool-v5/test/test.fork.ts
+++ b/tasks/20230711-composable-stable-pool-v5/test/test.fork.ts
@@ -293,7 +293,7 @@ describeForkTest('ComposableStablePool V5', 'mainnet', 17663500, function () {
       });
     });
   });
-  
+
   describe('read-only reentrancy protection', () => {
     let pool: Contract;
     let poolId: string;
@@ -461,7 +461,7 @@ describeForkTest('ComposableStablePool V5', 'mainnet', 17663500, function () {
     await expect(owner.sendTransaction(txA)).to.be.reverted;
     await expect(owner.sendTransaction(txB)).to.be.reverted;
   });
-  
+
   describe('factory disable', () => {
     it('the factory can be disabled', async () => {
       await authorizer.connect(govMultisig).grantRole(await actionId(factory, 'disable'), govMultisig.address);


### PR DESCRIPTION
# Description

See [this PR](https://github.com/balancer/balancer-v2-monorepo/pull/2549) in the monorepo, which fixes an obscure issue with the BaseSplitCodeFactory where, if you were very unlucky indeed, the second half of the contract might start with valid opcodes including a selfdestruct, which would brick the factory if executed.

This adds fork tests to all the pool factories, checking that this did not already happen, and should be carried forward into any future pool deployments (with corrected factory code, if it's a new release and not a patch).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

