### PR TITLE
Skip deprecated tests

### DIFF
--- a/tasks/deprecated/20210624-stable-pool/test/task.fork.ts
+++ b/tasks/deprecated/20210624-stable-pool/test/task.fork.ts
@@ -14,7 +14,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 
 import { getSigner, impersonate, getForkedNetwork, Task, TaskMode, describeForkTest } from '@src';
 
-describeForkTest('StablePoolFactory', 'mainnet', 14850000, function () {
+describeForkTest.skip('StablePoolFactory', 'mainnet', 14850000, function () {
   let owner: SignerWithAddress, whale: SignerWithAddress;
   let pool: Contract, factory: Contract, vault: Contract, usdc: Contract, dai: Contract;
 

--- a/tasks/deprecated/20210721-liquidity-bootstrapping-pool/test/task.fork.ts
+++ b/tasks/deprecated/20210721-liquidity-bootstrapping-pool/test/task.fork.ts
@@ -14,7 +14,7 @@ import { advanceToTimestamp, currentTimestamp, DAY, MINUTE, MONTH } from '@helpe
 
 import { describeForkTest, getSigner, getForkedNetwork, Task, TaskMode, impersonate } from '@src';
 
-describeForkTest('LiquidityBootstrappingPoolFactory', 'mainnet', 14850000, function () {
+describeForkTest.skip('LiquidityBootstrappingPoolFactory', 'mainnet', 14850000, function () {
   let owner: SignerWithAddress, whale: SignerWithAddress;
   let pool: Contract, factory: Contract, vault: Contract, usdc: Contract, dai: Contract;
 

--- a/tasks/deprecated/20210727-meta-stable-pool/test/task.fork.ts
+++ b/tasks/deprecated/20210727-meta-stable-pool/test/task.fork.ts
@@ -13,7 +13,7 @@ import { SwapKind } from '@helpers/models/types/types';
 
 import { describeForkTest, getSigner, getForkedNetwork, Task, TaskMode, impersonate } from '@src';
 
-describeForkTest('MetaStablePoolFactory', 'mainnet', 14850000, function () {
+describeForkTest.skip('MetaStablePoolFactory', 'mainnet', 14850000, function () {
   let owner: SignerWithAddress, whale: SignerWithAddress;
   let pool: Contract, factory: Contract, vault: Contract, usdc: Contract, dai: Contract;
 

--- a/tasks/deprecated/20210811-ldo-merkle/test/task.fork.ts
+++ b/tasks/deprecated/20210811-ldo-merkle/test/task.fork.ts
@@ -14,7 +14,7 @@ function encodeElement(address: string, balance: BigNumber): string {
   return ethers.utils.solidityKeccak256(['address', 'uint'], [address, balance]);
 }
 
-describeForkTest('MerkleRedeem', 'mainnet', 14850000, function () {
+describeForkTest.skip('MerkleRedeem', 'mainnet', 14850000, function () {
   let lp: SignerWithAddress, other: SignerWithAddress, whale: SignerWithAddress;
   let distributor: Contract, token: Contract;
 

--- a/tasks/deprecated/20210907-investment-pool/test/task.fork.ts
+++ b/tasks/deprecated/20210907-investment-pool/test/task.fork.ts
@@ -14,7 +14,7 @@ import { advanceToTimestamp, currentTimestamp, DAY, MINUTE, MONTH } from '@helpe
 
 import { describeForkTest, getSigners, getForkedNetwork, Task, TaskMode, impersonate } from '@src';
 
-describeForkTest('InvestmentPoolFactory', 'mainnet', 14850000, function () {
+describeForkTest.skip('InvestmentPoolFactory', 'mainnet', 14850000, function () {
   let owner: SignerWithAddress, wallet: SignerWithAddress, whale: SignerWithAddress;
   let pool: Contract, factory: Contract, vault: Contract, usdc: Contract, dai: Contract;
 

--- a/tasks/deprecated/20210913-bal-arbitrum-merkle/test/task.fork.ts
+++ b/tasks/deprecated/20210913-bal-arbitrum-merkle/test/task.fork.ts
@@ -14,7 +14,7 @@ function encodeElement(address: string, balance: BigNumber): string {
   return ethers.utils.solidityKeccak256(['address', 'uint'], [address, balance]);
 }
 
-describeForkTest('MerkleRedeem', 'arbitrum', 846769, function () {
+describeForkTest.skip('MerkleRedeem', 'arbitrum', 846769, function () {
   let lp: SignerWithAddress, other: SignerWithAddress, whale: SignerWithAddress;
   let distributor: Contract, token: Contract;
 

--- a/tasks/deprecated/20210928-mcb-arbitrum-merkle/test/task.fork.ts
+++ b/tasks/deprecated/20210928-mcb-arbitrum-merkle/test/task.fork.ts
@@ -14,7 +14,7 @@ function encodeElement(address: string, balance: BigNumber): string {
   return ethers.utils.solidityKeccak256(['address', 'uint'], [address, balance]);
 }
 
-describeForkTest('MerkleRedeem', 'arbitrum', 1731663, function () {
+describeForkTest.skip('MerkleRedeem', 'arbitrum', 1731663, function () {
   let lp: SignerWithAddress, other: SignerWithAddress, whale: SignerWithAddress;
   let distributor: Contract, token: Contract;
 

--- a/tasks/deprecated/20211203-batch-relayer/test/task.fork.ts
+++ b/tasks/deprecated/20211203-batch-relayer/test/task.fork.ts
@@ -13,7 +13,7 @@ import { MAX_UINT256 } from '@helpers/constants';
 
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigner } from '@src';
 
-describeForkTest('BatchRelayerLibrary', 'mainnet', 14850000, function () {
+describeForkTest.skip('BatchRelayerLibrary', 'mainnet', 14850000, function () {
   let task: Task;
 
   let relayer: Contract, library: Contract;

--- a/tasks/deprecated/20220413-arbitrum-root-gauge-factory/test/task.fork.ts
+++ b/tasks/deprecated/20220413-arbitrum-root-gauge-factory/test/task.fork.ts
@@ -14,7 +14,7 @@ import { expectTransferEvent } from '@helpers/expectTransfer';
 
 import { describeForkTest, getSigner, impersonate, getForkedNetwork, Task, TaskMode } from '@src';
 
-describeForkTest('ArbitrumRootGaugeFactory', 'mainnet', 14600000, function () {
+describeForkTest.skip('ArbitrumRootGaugeFactory', 'mainnet', 14600000, function () {
   let veBALHolder: SignerWithAddress, admin: SignerWithAddress, recipient: SignerWithAddress;
   let factory: Contract, gauge: Contract;
   let vault: Contract,

--- a/tasks/deprecated/20220413-polygon-root-gauge-factory/test/task.fork.ts
+++ b/tasks/deprecated/20220413-polygon-root-gauge-factory/test/task.fork.ts
@@ -14,7 +14,7 @@ import { ZERO_ADDRESS } from '@helpers/constants';
 
 import { describeForkTest, getSigner, impersonate, getForkedNetwork, Task, TaskMode } from '@src';
 
-describeForkTest('PolygonRootGaugeFactory', 'mainnet', 14600000, function () {
+describeForkTest.skip('PolygonRootGaugeFactory', 'mainnet', 14600000, function () {
   let veBALHolder: SignerWithAddress, admin: SignerWithAddress, recipient: SignerWithAddress;
   let factory: Contract, gauge: Contract;
   let vault: Contract,

--- a/tasks/deprecated/20220420-fee-distributor/test/test.fork.ts
+++ b/tasks/deprecated/20220420-fee-distributor/test/test.fork.ts
@@ -10,7 +10,7 @@ import { expectTransferEvent } from '@helpers/expectTransfer';
 
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode } from '@src';
 
-describeForkTest('FeeDistributor', 'mainnet', 14623150, function () {
+describeForkTest.skip('FeeDistributor', 'mainnet', 14623150, function () {
   let veBALHolder: SignerWithAddress, veBALHolder2: SignerWithAddress, feeCollector: SignerWithAddress;
   let distributor: Contract;
 

--- a/tasks/deprecated/20220609-stable-pool-v2/test/task.fork.ts
+++ b/tasks/deprecated/20220609-stable-pool-v2/test/task.fork.ts
@@ -14,7 +14,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 
 import { describeForkTest, getSigner, impersonate, getForkedNetwork, Task, TaskMode } from '@src';
 
-describeForkTest('StablePoolFactory', 'mainnet', 14850000, function () {
+describeForkTest.skip('StablePoolFactory', 'mainnet', 14850000, function () {
   let owner: SignerWithAddress, whale: SignerWithAddress, govMultisig: SignerWithAddress;
   let factory: Contract, vault: Contract, authorizer: Contract, usdc: Contract, dai: Contract, usdt: Contract;
 

--- a/tasks/deprecated/20220628-optimism-root-gauge-factory/test/task.fork.ts
+++ b/tasks/deprecated/20220628-optimism-root-gauge-factory/test/task.fork.ts
@@ -18,7 +18,7 @@ import { describeForkTest, getSigner, impersonate, getForkedNetwork, Task, TaskM
 // We then place the gauge deployed for this test into the "Arbitrum" type.
 // In production a proper gauge type should be created for the gauges deployed by this factory.
 
-describeForkTest('OptimismRootGaugeFactory', 'mainnet', 14850000, function () {
+describeForkTest.skip('OptimismRootGaugeFactory', 'mainnet', 14850000, function () {
   let veBALHolder: SignerWithAddress, admin: SignerWithAddress, recipient: SignerWithAddress;
   let factory: Contract, gauge: Contract;
   let vault: Contract,

--- a/tasks/deprecated/20220720-batch-relayer-v3/test/test.fork.ts
+++ b/tasks/deprecated/20220720-batch-relayer-v3/test/test.fork.ts
@@ -11,7 +11,7 @@ import { defaultAbiCoder } from '@ethersproject/abi/lib/abi-coder';
 
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode } from '@src';
 
-describeForkTest('BatchRelayerLibrary', 'mainnet', 15150000, function () {
+describeForkTest.skip('BatchRelayerLibrary', 'mainnet', 15150000, function () {
   let task: Task;
 
   let relayer: Contract, library: Contract;

--- a/tasks/deprecated/20220817-aave-rebalanced-linear-pool/test/test.fork.ts
+++ b/tasks/deprecated/20220817-aave-rebalanced-linear-pool/test/test.fork.ts
@@ -8,7 +8,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { SwapKind } from '@helpers/models/types/types';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigners } from '@src';
 
-describeForkTest('AaveLinearPoolFactory', 'mainnet', 15225000, function () {
+describeForkTest.skip('AaveLinearPoolFactory', 'mainnet', 15225000, function () {
   let owner: SignerWithAddress, holder: SignerWithAddress, other: SignerWithAddress;
   let factory: Contract, vault: Contract, usdc: Contract;
   let rebalancer: Contract;

--- a/tasks/deprecated/20220916-batch-relayer-v4/test/test.fork.ts
+++ b/tasks/deprecated/20220916-batch-relayer-v4/test/test.fork.ts
@@ -12,7 +12,7 @@ import { defaultAbiCoder } from '@ethersproject/abi/lib/abi-coder';
 
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode } from '@src';
 
-describeForkTest('BatchRelayerLibrary', 'mainnet', 15485000, function () {
+describeForkTest.skip('BatchRelayerLibrary', 'mainnet', 15485000, function () {
   let task: Task;
 
   let relayer: Contract, library: Contract;

--- a/tasks/deprecated/20221021-managed-pool/test/task.fork.ts
+++ b/tasks/deprecated/20221021-managed-pool/test/task.fork.ts
@@ -28,7 +28,7 @@ type ManagedPoolParams = {
   aumFeeId: BigNumberish;
 };
 
-describeForkTest('ManagedPoolFactory', 'mainnet', 15634000, function () {
+describeForkTest.skip('ManagedPoolFactory', 'mainnet', 15634000, function () {
   let owner: SignerWithAddress, whale: SignerWithAddress, govMultisig: SignerWithAddress;
   let factory: Contract,
     vault: Contract,

--- a/tasks/deprecated/20221122-composable-stable-pool-v2/test/test.fork.ts
+++ b/tasks/deprecated/20221122-composable-stable-pool-v2/test/test.fork.ts
@@ -17,7 +17,7 @@ import { SwapKind } from '@helpers/models/types/types';
 import { actionId } from '@helpers/models/misc/actions';
 import { expectEqualWithError } from '@helpers/relativeError';
 
-describeForkTest('ComposableStablePool', 'mainnet', 16000000, function () {
+describeForkTest.skip('ComposableStablePool', 'mainnet', 16000000, function () {
   let task: Task;
 
   let factory: Contract;

--- a/tasks/deprecated/20221202-timelock-authorizer/test/task.fork.ts
+++ b/tasks/deprecated/20221202-timelock-authorizer/test/task.fork.ts
@@ -16,7 +16,7 @@ import { AuthorizerDeployment } from '../../../20210418-authorizer/input';
 import { TimelockAuthorizerDeployment } from '../input';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-describeForkTest('TimelockAuthorizer', 'mainnet', 16076200, function () {
+describeForkTest.skip('TimelockAuthorizer', 'mainnet', 16076200, function () {
   let input: TimelockAuthorizerDeployment;
   let migrator: Contract, vault: Contract, newAuthorizer: Contract, oldAuthorizer: Contract;
   let root: SignerWithAddress;

--- a/tasks/deprecated/20221207-aave-rebalanced-linear-pool-v3/test/test.fork.ts
+++ b/tasks/deprecated/20221207-aave-rebalanced-linear-pool-v3/test/test.fork.ts
@@ -10,7 +10,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { SwapKind } from '@helpers/models/types/types';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigners } from '@src';
 
-describeForkTest('AaveLinearPoolFactory', 'mainnet', 15225000, function () {
+describeForkTest.skip('AaveLinearPoolFactory', 'mainnet', 15225000, function () {
   let owner: SignerWithAddress, holder: SignerWithAddress, other: SignerWithAddress;
   let factory: Contract, vault: Contract, usdt: Contract;
   let rebalancer: Contract;

--- a/tasks/deprecated/20230109-gauge-adder-v3/test/task.fork.ts
+++ b/tasks/deprecated/20230109-gauge-adder-v3/test/task.fork.ts
@@ -14,7 +14,7 @@ import TimelockAuthorizer from '@helpers/models/authorizer/TimelockAuthorizer';
 import { advanceTime, DAY } from '@helpers/time';
 import { ZERO_ADDRESS } from '@helpers/constants';
 
-describeForkTest('GaugeAdderV3', 'mainnet', 16370000, function () {
+describeForkTest.skip('GaugeAdderV3', 'mainnet', 16370000, function () {
   let factory: Contract;
   let adaptorEntrypoint: Contract;
   let authorizer: Contract;

--- a/tasks/deprecated/20230206-aave-rebalanced-linear-pool-v4/test/test.fork.ts
+++ b/tasks/deprecated/20230206-aave-rebalanced-linear-pool-v4/test/test.fork.ts
@@ -10,7 +10,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 import { SwapKind } from '@helpers/models/types/types';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigners } from '@src';
 
-describeForkTest('AaveLinearPoolFactory V4', 'mainnet', 16592300, function () {
+describeForkTest.skip('AaveLinearPoolFactory V4', 'mainnet', 16592300, function () {
   let owner: SignerWithAddress, holder: SignerWithAddress, other: SignerWithAddress;
   let factory: Contract, vault: Contract, usdt: Contract;
   let rebalancer: Contract;

--- a/tasks/deprecated/20230206-composable-stable-pool-v3/test/test.fork.ts
+++ b/tasks/deprecated/20230206-composable-stable-pool-v3/test/test.fork.ts
@@ -19,7 +19,7 @@ import { actionId } from '@helpers/models/misc/actions';
 import { expectEqualWithError } from '@helpers/relativeError';
 import { deploy } from '@src';
 
-describeForkTest('ComposableStablePool V3', 'mainnet', 16577000, function () {
+describeForkTest.skip('ComposableStablePool V3', 'mainnet', 16577000, function () {
   let task: Task;
 
   let factory: Contract;

--- a/tasks/deprecated/20230206-erc4626-linear-pool-v3/test/task.fork.ts
+++ b/tasks/deprecated/20230206-erc4626-linear-pool-v3/test/task.fork.ts
@@ -17,7 +17,7 @@ export enum SwapKind {
   GivenOut,
 }
 
-describeForkTest('ERC4626LinearPoolFactory', 'mainnet', 16550500, function () {
+describeForkTest.skip('ERC4626LinearPoolFactory', 'mainnet', 16550500, function () {
   let owner: SignerWithAddress, holder: SignerWithAddress, other: SignerWithAddress;
   let govMultisig: SignerWithAddress;
   let vault: Contract, authorizer: Contract, mainToken: Contract;

--- a/tasks/deprecated/20230206-weighted-pool-v3/test/task.fork.ts
+++ b/tasks/deprecated/20230206-weighted-pool-v3/test/task.fork.ts
@@ -16,7 +16,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 
 import { getSigner, impersonate, getForkedNetwork, Task, TaskMode, describeForkTest } from '@src';
 
-describeForkTest('WeightedPool V3', 'mainnet', 16577000, function () {
+describeForkTest.skip('WeightedPool V3', 'mainnet', 16577000, function () {
   let owner: SignerWithAddress,
     whale: SignerWithAddress,
     wstEthWhale: SignerWithAddress,

--- a/tasks/deprecated/20230213-gearbox-linear-pool/test/task.fork.ts
+++ b/tasks/deprecated/20230213-gearbox-linear-pool/test/task.fork.ts
@@ -16,7 +16,7 @@ export enum SwapKind {
   GivenOut,
 }
 
-describeForkTest('GearboxLinearPoolFactory', 'mainnet', 16636000, function () {
+describeForkTest.skip('GearboxLinearPoolFactory', 'mainnet', 16636000, function () {
   let owner: SignerWithAddress, holder: SignerWithAddress, other: SignerWithAddress;
   let vault: Contract, mainToken: Contract;
   let factory: Contract;

--- a/tasks/deprecated/20230213-yearn-linear-pool/test/task.fork.ts
+++ b/tasks/deprecated/20230213-yearn-linear-pool/test/task.fork.ts
@@ -16,7 +16,7 @@ export enum SwapKind {
   GivenOut,
 }
 
-describeForkTest('YearnLinearPoolFactory', 'mainnet', 16610000, function () {
+describeForkTest.skip('YearnLinearPoolFactory', 'mainnet', 16610000, function () {
   let owner: SignerWithAddress, holder: SignerWithAddress, other: SignerWithAddress;
   let vault: Contract, mainToken: Contract;
   let factory: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/composableStableV1.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/composableStableV1.fork.ts
@@ -21,7 +21,7 @@ import {
   PoolKind,
 } from './helpers/sharedStableParams';
 
-describeForkTest('BatchRelayerLibrary - Composable Stable V1', 'mainnet', 16083775, function () {
+describeForkTest.skip('BatchRelayerLibrary - Composable Stable V1', 'mainnet', 16083775, function () {
   let task: Task;
 
   let relayer: Contract, library: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/composableStableV2.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/composableStableV2.fork.ts
@@ -20,7 +20,7 @@ import {
   PoolKind,
 } from './helpers/sharedStableParams';
 
-describeForkTest('BatchRelayerLibrary - Composable Stable V2+', 'mainnet', 16789433, function () {
+describeForkTest.skip('BatchRelayerLibrary - Composable Stable V2+', 'mainnet', 16789433, function () {
   let task: Task;
 
   let relayer: Contract, library: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/compoundV2Wrapping.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/compoundV2Wrapping.fork.ts
@@ -6,7 +6,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { MAX_UINT256 } from '@helpers/constants';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigner } from '@src';
 
-describeForkTest('CompoundV2Wrapping', 'polygon', 40305420, function () {
+describeForkTest.skip('CompoundV2Wrapping', 'polygon', 40305420, function () {
   let task: Task;
   let relayer: Contract, library: Contract;
   let vault: Contract, authorizer: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/erc4626Wrapping.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/erc4626Wrapping.fork.ts
@@ -7,7 +7,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigner } from '@src';
 import { MAX_UINT256 } from '@helpers/constants';
 
-describeForkTest('ERC4626Wrapping', 'mainnet', 18412883, function () {
+describeForkTest.skip('ERC4626Wrapping', 'mainnet', 18412883, function () {
   let task: Task;
   let relayer: Contract, library: Contract;
   let vault: Contract, authorizer: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/eulerWrapping.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/eulerWrapping.fork.ts
@@ -6,7 +6,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigner } from '@src';
 import { MAX_UINT256 } from '@helpers/constants';
 
-describeForkTest('EulerWrapping', 'mainnet', 16636628, function () {
+describeForkTest.skip('EulerWrapping', 'mainnet', 16636628, function () {
   let task: Task;
   let relayer: Contract, library: Contract;
   let vault: Contract, authorizer: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/gearboxWrapping.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/gearboxWrapping.fork.ts
@@ -6,7 +6,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigner } from '@src';
 import { MAX_UINT256 } from '@helpers/constants';
 
-describeForkTest('GearboxWrapping', 'mainnet', 16622559, function () {
+describeForkTest.skip('GearboxWrapping', 'mainnet', 16622559, function () {
   let task: Task;
   let relayer: Contract, library: Contract;
   let vault: Contract, authorizer: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/legacyStable.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/legacyStable.fork.ts
@@ -19,7 +19,7 @@ import {
   PoolKind,
 } from './helpers/sharedStableParams';
 
-describeForkTest('BatchRelayerLibrary - Legacy Stable', 'mainnet', 14860000, function () {
+describeForkTest.skip('BatchRelayerLibrary - Legacy Stable', 'mainnet', 14860000, function () {
   let task: Task;
 
   let relayer: Contract, library: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/siloWrapping.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/siloWrapping.fork.ts
@@ -5,7 +5,7 @@ import { BigNumberish, bn } from '@helpers/numbers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigner } from '@src';
 
-describeForkTest('SiloWrapping', 'mainnet', 16622559, function () {
+describeForkTest.skip('SiloWrapping', 'mainnet', 16622559, function () {
   let task: Task;
   let relayer: Contract, library: Contract;
   let vault: Contract, authorizer: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/stablePhantom.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/stablePhantom.fork.ts
@@ -20,7 +20,7 @@ import {
   initialBalances,
 } from './helpers/sharedStableParams';
 
-describeForkTest('Stable Phantom Exit', 'mainnet', 13776527, function () {
+describeForkTest.skip('Stable Phantom Exit', 'mainnet', 13776527, function () {
   let vault: Contract, authorizer: Contract;
 
   before('load vault and tokens', async () => {

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/test.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/test.fork.ts
@@ -10,7 +10,7 @@ import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode } from 
 import * as expectEvent from '@helpers/expectEvent';
 import { sharedBeforeEach } from '@helpers/sharedBeforeEach';
 
-describeForkTest('BatchRelayerLibrary', 'mainnet', 15485000, function () {
+describeForkTest.skip('BatchRelayerLibrary', 'mainnet', 15485000, function () {
   let task: Task;
 
   let relayer: Contract, library: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/tetuWrapping.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/tetuWrapping.fork.ts
@@ -6,7 +6,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigner } from '@src';
 import { MAX_UINT256 } from '@helpers/constants';
 
-describeForkTest('TetuWrapping', 'polygon', 37945364, function () {
+describeForkTest.skip('TetuWrapping', 'polygon', 37945364, function () {
   let task: Task;
   let relayer: Contract, library: Contract;
   let vault: Contract, authorizer: Contract;

--- a/tasks/deprecated/20230314-batch-relayer-v5/test/yearnWrapping.fork.ts
+++ b/tasks/deprecated/20230314-batch-relayer-v5/test/yearnWrapping.fork.ts
@@ -6,7 +6,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { describeForkTest, impersonate, getForkedNetwork, Task, TaskMode, getSigner } from '@src';
 import { MAX_UINT256 } from '@helpers/constants';
 
-describeForkTest('YearnWrapping', 'mainnet', 16622559, function () {
+describeForkTest.skip('YearnWrapping', 'mainnet', 16622559, function () {
   let task: Task;
   let relayer: Contract, library: Contract;
   let vault: Contract, authorizer: Contract;

--- a/tasks/deprecated/20230315-silo-linear-pool/test/test.fork.ts
+++ b/tasks/deprecated/20230315-silo-linear-pool/test/test.fork.ts
@@ -16,7 +16,7 @@ export enum SwapKind {
   GivenOut,
 }
 
-describeForkTest('SiloLinearPoolFactory', 'mainnet', 16478568, function () {
+describeForkTest.skip('SiloLinearPoolFactory', 'mainnet', 16478568, function () {
   let owner: SignerWithAddress, holder: SignerWithAddress, other: SignerWithAddress;
   let factory: Contract, vault: Contract, usdc: Contract;
   let rebalancer: Contract;

--- a/tasks/deprecated/20230316-avax-l2-balancer-pseudo-minter/test/test.fork.ts
+++ b/tasks/deprecated/20230316-avax-l2-balancer-pseudo-minter/test/test.fork.ts
@@ -13,7 +13,7 @@ import { impersonate } from '@src';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { ANY_ADDRESS } from '@helpers/constants';
 
-describeForkTest('L2BalancerPseudoMinter', 'arbitrum', 70407500, function () {
+describeForkTest.skip('L2BalancerPseudoMinter', 'arbitrum', 70407500, function () {
   let vault: Contract, authorizer: Contract;
   let pseudoMinter: Contract;
   let admin: SignerWithAddress;

--- a/tasks/deprecated/20230320-composable-stable-pool-v4/test/test.fork.ts
+++ b/tasks/deprecated/20230320-composable-stable-pool-v4/test/test.fork.ts
@@ -20,7 +20,7 @@ import { expectEqualWithError } from '@helpers/relativeError';
 import { deploy } from '@src';
 import { randomBytes } from 'ethers/lib/utils';
 
-describeForkTest('ComposableStablePool V4', 'mainnet', 16577000, function () {
+describeForkTest.skip('ComposableStablePool V4', 'mainnet', 16577000, function () {
   let task: Task;
 
   let factory: Contract;

--- a/tasks/deprecated/20230527-l2-gauge-checkpointer/test/task.fork.ts
+++ b/tasks/deprecated/20230527-l2-gauge-checkpointer/test/task.fork.ts
@@ -14,7 +14,7 @@ import { actionId } from '@helpers/models/misc/actions';
 
 // This block number is before the manual weekly checkpoint. This ensures gauges will actually be checkpointed.
 // This test verifies the checkpointer against the manual transactions for the given period.
-describeForkTest('L2GaugeCheckpointer', 'mainnet', 17332499, function () {
+describeForkTest.skip('L2GaugeCheckpointer', 'mainnet', 17332499, function () {
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
   enum GaugeType {

--- a/tasks/deprecated/20230529-avalanche-root-gauge-factory/test/task.fork.ts
+++ b/tasks/deprecated/20230529-avalanche-root-gauge-factory/test/task.fork.ts
@@ -16,7 +16,7 @@ import { actionId } from '@helpers/models/misc/actions';
 import { describeForkTest, getSigner, impersonate, getForkedNetwork, Task, TaskMode } from '@src';
 import { WeightedPoolEncoder } from '@helpers/models/pools/weighted/encoder';
 
-describeForkTest('AvalancheRootGaugeFactory', 'mainnet', 17395000, function () {
+describeForkTest.skip('AvalancheRootGaugeFactory', 'mainnet', 17395000, function () {
   let veBALHolder: SignerWithAddress, admin: SignerWithAddress, recipient: SignerWithAddress;
   let daoMultisig: SignerWithAddress;
   let factory: Contract, gauge: Contract;

--- a/tasks/deprecated/20230711-composable-stable-pool-v5/test/test.fork.ts
+++ b/tasks/deprecated/20230711-composable-stable-pool-v5/test/test.fork.ts
@@ -20,7 +20,7 @@ import { expectEqualWithError } from '@helpers/relativeError';
 import { deploy } from '@src';
 import { randomBytes } from 'ethers/lib/utils';
 
-describeForkTest('ComposableStablePool V5', 'mainnet', 17663500, function () {
+describeForkTest.skip('ComposableStablePool V5', 'mainnet', 17663500, function () {
   let task: Task;
 
   let factory: Contract;

--- a/tasks/deprecated/20230731-stakeless-gauge-checkpointer/test/task-base.fork.ts
+++ b/tasks/deprecated/20230731-stakeless-gauge-checkpointer/test/task-base.fork.ts
@@ -16,7 +16,7 @@ import { actionId } from '@helpers/models/misc/actions';
 // This test verifies the checkpointer against the manual transactions for the given period.
 // This test is exactly the same as the one in 20230527-l2-gauge-checkpointer but using the new artifacts.
 // It validates that the new version of the checkpointer can still do the same as the previous one in the base case.
-describeForkTest('StakelessGaugeCheckpointer - Base', 'mainnet', 17332499, function () {
+describeForkTest.skip('StakelessGaugeCheckpointer - Base', 'mainnet', 17332499, function () {
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
   enum GaugeType {

--- a/tasks/deprecated/20230731-stakeless-gauge-checkpointer/test/task.fork.ts
+++ b/tasks/deprecated/20230731-stakeless-gauge-checkpointer/test/task.fork.ts
@@ -17,7 +17,7 @@ import { WEEK, currentWeekTimestamp } from '@helpers/time';
 // The only gauge under test should have been checkpointed at this block.
 // The contract in `20230527-l2-gauge-checkpointer` would skip it because it measures the gauge relative weight in
 // the current week, whereas the new version does so in the previous week.
-describeForkTest('StakelessGaugeCheckpointer', 'mainnet', 17431930, function () {
+describeForkTest.skip('StakelessGaugeCheckpointer', 'mainnet', 17431930, function () {
   /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
   enum GaugeType {


### PR DESCRIPTION
# Description

Skip fork tests for deprecated tasks.
 
I don't see a reason for this to keep going other than wasting some CPU cycles and keep increasing the universe's total entropy each time they are executed.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A