### PR TITLE
Missing action ids for v3 pool weighted

### DIFF
--- a/action-ids/gnosis/action-ids.json
+++ b/action-ids/gnosis/action-ids.json
@@ -628,5 +628,14 @@
         "stopAmplificationParameterUpdate()": "0x66a9e5de1de4dbcb0b1d3979ca06bd4bb8ba535a1f67873ed92779cfd976dcf0"
       }
     }
+  },
+  "20241205-v3-weighted-pool": {
+    "WeightedPoolFactory": {
+      "useAdaptor": false,
+      "actionIds": {
+        "create(string,string,(address,uint8,address,bool)[],uint256[],(address,address,address),uint256,address,bool,bool,bytes32)": "0x19073272231afac965e8df45941fc6a359b6063557f2d9dfe86cc2770735a50b",
+        "disable()": "0x0b57c528b17bebb5b75282268198cc2f48585d04488cdc16020206499ed61769"
+      }
+    }
   }
 }

--- a/action-ids/mainnet/action-ids.json
+++ b/action-ids/mainnet/action-ids.json
@@ -1621,5 +1621,14 @@
         "stopAmplificationParameterUpdate()": "0xeeed27c13054947e3283c26fca5c34c2e514ef8caa98f1c6a6778c06f1d247da"
       }
     }
+  },
+  "20241205-v3-weighted-pool": {
+    "WeightedPoolFactory": {
+      "useAdaptor": false,
+      "actionIds": {
+        "create(string,string,(address,uint8,address,bool)[],uint256[],(address,address,address),uint256,address,bool,bool,bytes32)": "0x2faac302cfb0f5c70816211ce043fa7149206b8a99025bafbd7d352b648e3e61",
+        "disable()": "0xed6f8a5f0602534601834cae86e16a9424b7bf30c562d15bd781fbcd5026d9a1"
+      }
+    }
   }
 }

--- a/action-ids/sepolia/action-ids.json
+++ b/action-ids/sepolia/action-ids.json
@@ -734,5 +734,14 @@
         "stopAmplificationParameterUpdate()": "0xa5455f6ee362021a73c69b1c3865f21493266a1eb878508937fabf493a942e34"
       }
     }
+  },
+  "20241205-v3-weighted-pool": {
+    "WeightedPoolFactory": {
+      "useAdaptor": false,
+      "actionIds": {
+        "create(string,string,(address,uint8,address,bool)[],uint256[],(address,address,address),uint256,address,bool,bool,bytes32)": "0xd980dee429e25ce4da26161ccf91d7c6ee87d86f3915007e4537e0d35e3b8259",
+        "disable()": "0x7c0130294f0e03f01aba8bab022bb25ff63245a75d2f2d2f6cc33d26ab6b23b9"
+      }
+    }
   }
 }


### PR DESCRIPTION
# Description

I was thinking about the pool itself, but forgot about `disable` in the factory. This PR wraps up V3 weighted pool factory deployment.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A