### PR TITLE
Check artifacts iterating artifacts, not build info

### DIFF
--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -47,10 +47,11 @@ export function checkArtifact(task: Task): void {
     readmeLines = readmeContents.split('\n');
   }
 
-  const buildInfoDirectory = path.resolve(task.dir(), 'build-info');
-  if (existsSync(buildInfoDirectory) && statSync(buildInfoDirectory).isDirectory()) {
-    for (const buildInfoFileName of readdirSync(buildInfoDirectory)) {
-      const fileName = path.parse(buildInfoFileName).name;
+  const artifactDirectory = path.resolve(task.dir(), 'artifact');
+
+  if (existsSync(artifactDirectory) && statSync(artifactDirectory).isDirectory()) {
+    for (const artifactFileName of readdirSync(artifactDirectory)) {
+      const fileName = path.parse(artifactFileName).name;
       const contractName = fileName;
 
       const expectedArtifact = task.artifact(contractName, fileName);

--- a/v2/tasks/20211202-no-protocol-fee-lbp/readme.md
+++ b/v2/tasks/20211202-no-protocol-fee-lbp/readme.md
@@ -16,4 +16,5 @@ Deployment of the `NoProtocolFeeLiquidityBootstrappingPool`, for Liquidity Boots
 - [Fraxtal mainnet addresses](./output/fraxtal.json)
 - [Mode mainnet addresses](./output/mode.json)
 - [Sepolia testnet addresses](./output/sepolia.json)
+- [`LiquidityBootstrappingPool` artifact](./artifact/LiquidityBootstrappingPool.json)
 - [`NoProtocolFeeLiquidityBootstrappingPoolFactory` artifact](./artifact/NoProtocolFeeLiquidityBootstrappingPoolFactory.json)


### PR DESCRIPTION
# Description

`check-artifacts` should iterate artifacts and compare to what you extract using build info.
In some cases, more than one artifact comes out of the same build info, and it's not being checked properly now.

If there's more than one build info and each artifact matches a different build info file this will still work.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A