### PR TITLE
Add factory name to action IDs generator / checks

### DIFF
--- a/action-ids/sepolia/action-ids.json
+++ b/action-ids/sepolia/action-ids.json
@@ -788,7 +788,8 @@
         "incrementNonce()": "0x1e67f9bb3ad5504d9e909e3bbde7cd022f22070821383f1dbad5e5ef56a76491",
         "startAmplificationParameterUpdate(uint256,uint256)": "0xe8d4232755d5ac7e7131688c9dd86abe82281201f438d1cb4b08e52d1c732f00",
         "stopAmplificationParameterUpdate()": "0x093b5314ebb2e139c41e0f78f326bc5406c6f86ba6aad79c650c0aa974620e40"
-      }
+      },
+      "factoryName": "StableSurgePoolFactory"
     }
   }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -143,10 +143,14 @@ task('save-action-ids', `Print the action IDs for a particular contract and chec
   .addOptionalParam('id', 'Specific task ID')
   .addOptionalParam('name', 'Contract name')
   .addOptionalParam('address', 'Address of Pool created from a factory')
+  .addOptionalParam('factory', 'Name of pool factory (only if it is not `<contract>Factory`')
   .setAction(
-    async (args: { id: string; name: string; address?: string; verbose?: boolean }, hre: HardhatRuntimeEnvironment) => {
+    async (
+      args: { id: string; name: string; address?: string; factory?: string; verbose?: boolean },
+      hre: HardhatRuntimeEnvironment
+    ) => {
       async function saveActionIdsTask(
-        args: { id: string; name: string; address?: string; verbose?: boolean },
+        args: { id: string; name: string; address?: string; factory?: string; verbose?: boolean },
         hre: HardhatRuntimeEnvironment
       ) {
         Logger.setDefaults(false, args.verbose || false);
@@ -160,7 +164,7 @@ task('save-action-ids', `Print the action IDs for a particular contract and chec
             );
           }
           const task = new Task(args.id, TaskMode.READ_ONLY, hre.network.name);
-          await saveActionIds(task, args.name, args.address);
+          await saveActionIds(task, args.name, args.address, args.factory);
           return;
         }
 

--- a/src/actionId.ts
+++ b/src/actionId.ts
@@ -21,7 +21,12 @@ export type ActionIdData = Record<string, string>;
 
 export type TaskActionIds = Record<string, ContractActionIdData>;
 
-export type ContractActionIdData = { useAdaptor: boolean; factoryOutput?: string; actionIds: ActionIdData };
+export type ContractActionIdData = {
+  useAdaptor: boolean;
+  factoryOutput?: string;
+  factoryName?: string;
+  actionIds: ActionIdData;
+};
 
 export type ActionIdInfo = {
   taskId: string;
@@ -51,10 +56,15 @@ export function getTaskActionIds(task: Task): TaskActionIds {
   return actionIdFileContents[task.id];
 }
 
-export async function saveActionIds(task: Task, contractName: string, factoryOutput?: string): Promise<void> {
+export async function saveActionIds(
+  task: Task,
+  contractName: string,
+  factoryOutput?: string,
+  factoryName?: string
+): Promise<void> {
   logger.log(`Generating action IDs for ${contractName} of ${task.id}`, '');
 
-  const { useAdaptor, actionIds } = await getActionIds(task, contractName, factoryOutput);
+  const { useAdaptor, actionIds } = await getActionIds(task, contractName, factoryOutput, factoryName);
 
   const actionIdsDir = path.join(ACTION_ID_DIRECTORY, task.network);
   if (!fs.existsSync(actionIdsDir)) fs.mkdirSync(actionIdsDir, { recursive: true });
@@ -66,7 +76,7 @@ export async function saveActionIds(task: Task, contractName: string, factoryOut
 
   // Write the new entry.
   newFileContents[task.id] = newFileContents[task.id] ?? {};
-  newFileContents[task.id][contractName] = { useAdaptor, factoryOutput, actionIds };
+  newFileContents[task.id][contractName] = { useAdaptor, factoryOutput, actionIds, factoryName };
 
   fs.writeFileSync(filePath, JSON.stringify(newFileContents, null, 2));
 }
@@ -79,7 +89,8 @@ export async function checkActionIds(task: Task): Promise<void> {
     const { useAdaptor: expectedUseAdaptor, actionIds: expectedActionIds } = await getActionIds(
       task,
       contractName,
-      actionIdData.factoryOutput
+      actionIdData.factoryOutput,
+      actionIdData.factoryName
     );
 
     const adaptorUsageMatch = actionIdData.useAdaptor === expectedUseAdaptor;
@@ -149,7 +160,8 @@ export function checkActionIdUniqueness(network: string): void {
 export async function getActionIds(
   task: Task,
   contractName: string,
-  factoryOutput?: string
+  factoryOutput?: string,
+  factoryName?: string
 ): Promise<{ useAdaptor: boolean; actionIds: ActionIdData }> {
   const artifact = task.artifact(contractName);
 
@@ -162,7 +174,7 @@ export async function getActionIds(
     .filter(([, func]) => !ignoredFunctions.includes(func.format()))
     .sort(([sigA], [sigB]) => (sigA < sigB ? -1 : 1)); // Sort functions alphabetically.
 
-  const { useAdaptor, actionIdSource } = await getActionIdSource(task, contractName, factoryOutput);
+  const { useAdaptor, actionIdSource } = await getActionIdSource(task, contractName, factoryOutput, factoryName);
   const actionIds = await getActionIdsFromSource(contractFunctions, actionIdSource);
 
   return { useAdaptor, actionIds };
@@ -171,7 +183,8 @@ export async function getActionIds(
 async function getActionIdSource(
   task: Task,
   contractName: string,
-  factoryOutput?: string
+  factoryOutput?: string,
+  factoryName?: string
 ): Promise<{ useAdaptor: boolean; actionIdSource: Contract }> {
   const artifact = task.artifact(contractName);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -186,7 +199,7 @@ async function getActionIdSource(
 
   if (contractIsAuthorizerAware) {
     if (factoryOutput) {
-      await checkFactoryOutput(task, contractName, factoryOutput);
+      await checkFactoryOutput(task, contractName, factoryOutput, factoryName);
       return { useAdaptor: false, actionIdSource: await task.instanceAt(contractName, factoryOutput) };
     } else {
       return { useAdaptor: false, actionIdSource: await task.deployedInstance(contractName) };
@@ -236,15 +249,17 @@ function getDuplicateActionIds(actionIdFileContents: Record<string, TaskActionId
   return duplicateActionIdsMapping;
 }
 
-async function checkFactoryOutput(task: Task, contractName: string, factoryOutput: string) {
+async function checkFactoryOutput(task: Task, contractName: string, factoryOutput: string, factoryName?: string) {
   // We must check that the factory output is actually an instance of the expected contract type. This is
   // not trivial due to usage of immutable and lack of knowledge of constructor arguments. However, this scenario
   // only arises with Pools created from factories, all of which share a useful property: their factory contract
   // name is <contractName>Factory, and they all have a function called 'isPoolFromFactory' we can use for this.
 
-  const factory = await task.deployedInstance(`${contractName}Factory`);
+  factoryName = factoryName ?? `${contractName}Factory`;
+
+  const factory = await task.deployedInstance(factoryName);
   if (!(await factory.isPoolFromFactory(factoryOutput))) {
-    throw Error(`The contract at ${factoryOutput} is not an instance of a ${contractName}`);
+    throw Error(`The contract at ${factoryOutput} is not an instance of a ${contractName} coming from ${factoryName}`);
   }
 }
 


### PR DESCRIPTION
# Description

CI fails in #152 because the pools are called `StablePool`, but the factory is `StableSurgePoolFactory` instead of `<contract>Factory`.

This is an edge case but might happen again in the future, and in any case we need CI to pass with the current deployment. This change adds one more optional parameter that allows indicating what the factory name is.

It's backwards compatible; if the usual format is respected there's no need to use the new argument. But in this case, the command looks like this:
```
hh save-action-ids --id 20250121-v3-stable-surge --network sepolia --name StablePool --address 0x132F4bAa39330d9062fC52d81dF72F601DF8C01f --factory StableSurgePoolFactory
```

Merge this one on top of #152 first, then merge #152 so that CI passes.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A