### PR TITLE
Update the task deprecation template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/deployment-preparation-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/deployment-preparation-template.md
@@ -14,8 +14,9 @@
 
 - [ ] Old task was moved to `deprecated/` directory
 - [ ] Deployments `README` is updated: old task is moved to the 'deprecated' section, and links are updated with the `deprecated/` prefix
-- [ ] Old task imports in `index.ts`, `input.ts` and fork tests are updated
+- [ ] Old task fork test is skipped
 - [ ] Old task `README` is updated with a warning sign, a link to the replacement task and a short description <!-- Explain why it was deprecated -->
+- [ ] Addresses are rebuilt to reflect contract status
 
 ## Code checklist:
 


### PR DESCRIPTION
# Description

The base scripts have evolved since the templates were introduced, and the deprecation seems a bit out-of-date. It's usually unnecessary to modify anything in the input/index files now, and we are skipping the fork test for deprecated tasks.

We've also added the address generator, which is easy to forget about.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

