### PR TITLE
Fix the local EVM issue

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -85,7 +85,6 @@ export default class Task {
   }
 
   async instanceAt(name: string, address: string): Promise<Contract> {
-    await this.saveInInternalEVMState(address);
     return instanceAt(this.artifact(name), address);
   }
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -61,6 +61,7 @@ type ContractInfo = {
 export default class Task {
   id: string;
   mode: TaskMode;
+  evm: Promise<EVM>;
 
   _network?: Network;
   _verifier?: Verifier;
@@ -71,6 +72,7 @@ export default class Task {
     this.mode = mode;
     this._network = network;
     this._verifier = verifier;
+    this.evm = this.createEVM();
   }
 
   get network(): string {
@@ -83,6 +85,7 @@ export default class Task {
   }
 
   async instanceAt(name: string, address: string): Promise<Contract> {
+    await this.saveInInternalEVMState(address);
     return instanceAt(this.artifact(name), address);
   }
 
@@ -161,7 +164,8 @@ export default class Task {
   async saveAndVerifyFactoryContracts(
     contractsInfo: Array<ContractInfo>,
     deployTransaction?: ethers.providers.TransactionReceipt,
-    externalTask?: Task
+    externalTask?: Task,
+    factoryAddress?: string
   ): Promise<void> {
     const { ethers } = await import('hardhat');
 
@@ -176,14 +180,13 @@ export default class Task {
     // For instance, vault-factory-v2, where for safety we don't want to duplicate the artifacts.
     const artifactSource = externalTask === undefined ? this : externalTask;
 
-    const evm = await this.createEVM();
     for (const contractInfo of contractsInfo) {
       const isDeployedBytecodeValid = await this.checkBytecodeAndSaveEVMState(
-        evm,
         deployTransaction,
         artifactSource.artifact(contractInfo.name),
         contractInfo.expectedAddress,
-        contractInfo.args
+        contractInfo.args,
+        factoryAddress
       );
 
       if (isDeployedBytecodeValid && this.mode === TaskMode.CHECK) {
@@ -224,12 +227,13 @@ export default class Task {
     return evm;
   }
 
+  // NOTE: If a contract is deployed by a factory, we must set the factoryAddress in the function arguments.
   async checkBytecodeAndSaveEVMState(
-    evm: EVM,
     deployTransaction: ethers.providers.TransactionReceipt,
     artifact: Artifact,
     contractAddress: string,
-    args: Array<Param> = []
+    args: Array<Param> = [],
+    factoryAddress?: string
   ): Promise<boolean> {
     const { ethers } = await import('hardhat');
 
@@ -244,9 +248,12 @@ export default class Task {
       throw Error(`Could not find block ${deployTransaction.blockNumber}`);
     }
 
+    const evm = await this.evm;
     const res = await evm.runCode({
       code: runBytecode,
       to: Address.fromString(contractAddress),
+      caller: factoryAddress ? Address.fromString(factoryAddress) : Address.fromString(deployTransaction.from),
+      origin: Address.fromString(deployTransaction.from),
       block: {
         header: {
           number: BigInt(block.number),
@@ -294,6 +301,8 @@ export default class Task {
       this.save({ [name]: instance });
       logger.success(`Deployed ${name} at ${instance.address}`);
 
+      await this.saveInInternalEVMState(instance.address);
+
       if (this.mode === TaskMode.LIVE) {
         saveContractDeploymentTransactionHash(instance.address, instance.deployTransaction.hash, this.network);
       }
@@ -303,6 +312,16 @@ export default class Task {
     }
 
     return instance;
+  }
+
+  async saveInInternalEVMState(address: string): Promise<void> {
+    const { ethers } = await import('hardhat');
+    const evm = await this.evm;
+
+    await evm.stateManager.putContractCode(
+      Address.fromString(address),
+      hexToBytes(await ethers.provider.getCode(address))
+    );
   }
 
   async verify(

--- a/v2/tasks/20231031-batch-relayer-v6/index.ts
+++ b/v2/tasks/20231031-batch-relayer-v6/index.ts
@@ -15,7 +15,7 @@ export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise
   const relayerLibrary = await task.deployAndVerify('BatchRelayerLibrary', relayerLibraryArgs, from, force);
 
   // The relayer library automatically also deploys the query library, and then the relayer itself: we must verify them
-  const relayer: Contract = await task.instanceAt('BalancerRelayer', relayerLibrary.getEntrypoint());
+  const relayer: Contract = await task.instanceAt('BalancerRelayer', await relayerLibrary.getEntrypoint());
   const queryLibrary: string = await relayer.getQueryLibrary();
   const relayerAddress = await relayer.address;
 

--- a/v3/tasks/20250321-v3-vault-factory-v2/index.ts
+++ b/v3/tasks/20250321-v3-vault-factory-v2/index.ts
@@ -1,5 +1,5 @@
 import { VaultFactoryDeployment } from './input';
-import { deploy, Task, TaskMode, TaskRunOptions } from '@src';
+import { Task, TaskMode, TaskRunOptions } from '@src';
 import { ethers } from 'hardhat';
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
@@ -27,7 +27,7 @@ export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise
 
   // Deploy the ProtocolFeeController from the artifact, as it won't be there yet on new chains.
   // Must be AFTER the VaultFactory, or the deployer account nonce will be incorrect.
-  const feeControllerTask = new Task('20250214-v3-protocol-fee-controller-v2', TaskMode.READ_ONLY);
+  new Task('20250214-v3-protocol-fee-controller-v2', TaskMode.READ_ONLY);
   const args = [vaultAddress, input.InitialGlobalProtocolSwapFee, input.InitialGlobalProtocolYieldFee];
 
   const protocolFeeController = await task.deployAndVerify('ProtocolFeeController', args, from, force);

--- a/v3/tasks/20250321-v3-vault-factory-v2/index.ts
+++ b/v3/tasks/20250321-v3-vault-factory-v2/index.ts
@@ -30,10 +30,7 @@ export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise
   const feeControllerTask = new Task('20250214-v3-protocol-fee-controller-v2', TaskMode.READ_ONLY);
   const args = [vaultAddress, input.InitialGlobalProtocolSwapFee, input.InitialGlobalProtocolYieldFee];
 
-  const protocolFeeController = await deploy(feeControllerTask.artifact('ProtocolFeeController'), args, from);
-  task.save({ ProtocolFeeController: protocolFeeController });
-
-  await feeControllerTask.verify('ProtocolFeeController', protocolFeeController.address, args);
+  const protocolFeeController = await task.deployAndVerify('ProtocolFeeController', args, from, force);
 
   // Deploy the Vault contracts.
   const deployTransaction = await task.deployFactoryContracts(


### PR DESCRIPTION
<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. -->
<!-- Otherwise, delete everything before #Description -->

# Description

This PR fixes an issue with loading contracts into the local EVM. Since ProtocolFeeController was deployed separately from the factory, the local EVM state did not have the ProtocolFeeController contract when verifying the Vault.

In this PR, the local EVM is made static for the entire task and loads the contract code for contracts that go through the deployAndVerify function.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [ ] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
