### PR TITLE
Changelog nitpick, change avax explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Deployed V3 Gyro E-CLP Factory to all networks.
 - Deployed V3 Gyro 2-CLP Factory to all networks.
 - Deployed V3 Stable Pool Factory V2 to all networks.
-- Deployed V3 Stable Surg Hook V2 to all networks.
+- Deployed V3 Stable Surge Hook V2 to all networks.
 - Deployed V3 Stable Surge Pool Factory V2 to all networks.
 - Deployed V3 Vault Explorer V2 to all networks.
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -472,7 +472,7 @@ export default {
   etherscan: {
     customChains: [
       {
-        network: 'zkemv',
+        network: 'zkevm',
         chainId: 1101,
         urls: {
           apiURL: 'https://api-zkevm.polygonscan.com/api',
@@ -501,6 +501,14 @@ export default {
         urls: {
           apiURL: 'https://api.routescan.io/v2/network/mainnet/evm/34443/etherscan',
           browserURL: 'https://modescan.io',
+        },
+      },
+      {
+        network: 'avalanche',
+        chainId: 43114,
+        urls: {
+          apiURL: 'https://api.snowscan.xyz/api',
+          browserURL: 'https://snowscan.xyz/',
         },
       },
     ],


### PR DESCRIPTION
# Description

Change default avax explorer (contracts are now verified there too); Tenderly doesn't seem to be using snowtrace.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [x] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A