### PR TITLE
Tolerate HTML status 429 in the new linkspector

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,3 +1,7 @@
 dirs:
   - .
 useGitIgnore: true
+aliveStatusCodes:
+  - 200
+  - 429
+  


### PR DESCRIPTION
# Description

We are getting some 429 codes that are causing the new link inspector to fail. This should address that.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
