### PR TITLE
Spare getLogs call for contract checks.

### DIFF
--- a/v2/scripts/20230130-ta-transition-migrator/index.ts
+++ b/v2/scripts/20230130-ta-transition-migrator/index.ts
@@ -10,17 +10,19 @@ export default async (task: Task, { force, from }: TaskRunOptions = {}): Promise
 
   const inputRoles = [...input.Roles, ...input.DelayedRoles];
 
-  // Filter excluded roles in inputs file from on-chain roles.
-  const onChainRoles = (await getTransitionRoles('mainnet', TRANSITION_START_BLOCK, TRANSITION_END_BLOCK)).filter(
-    (role) => !excludedRoles.find((excludedRole) => isRoleEqual(excludedRole, role))
-  );
+  if (task.mode !== TaskMode.CHECK) {
+    // Filter excluded roles in inputs file from on-chain roles.
+    const onChainRoles = (await getTransitionRoles('mainnet', TRANSITION_START_BLOCK, TRANSITION_END_BLOCK)).filter(
+      (role) => !excludedRoles.find((excludedRole) => isRoleEqual(excludedRole, role))
+    );
 
-  const onchainInputMatch = onChainRoles.every((cRole) => inputRoles.find((iRole) => isRoleEqual(cRole, iRole)));
-  const inputOnchainMatch = inputRoles.every((iRole) => onChainRoles.find((cRole) => isRoleEqual(iRole, cRole)));
-  const rolesMatch = onChainRoles.length === inputRoles.length && onchainInputMatch && inputOnchainMatch;
+    const onchainInputMatch = onChainRoles.every((cRole) => inputRoles.find((iRole) => isRoleEqual(cRole, iRole)));
+    const inputOnchainMatch = inputRoles.every((iRole) => onChainRoles.find((cRole) => isRoleEqual(iRole, cRole)));
+    const rolesMatch = onChainRoles.length === inputRoles.length && onchainInputMatch && inputOnchainMatch;
 
-  if (!rolesMatch) {
-    throw new Error('Input permissions do not match on-chain roles granted to old authorizer');
+    if (!rolesMatch) {
+      throw new Error('Input permissions do not match on-chain roles granted to old authorizer');
+    }
   }
 
   const args = [input.OldAuthorizer, input.NewAuthorizer, inputRoles];


### PR DESCRIPTION
# Description

Spare some unnecessary `eth_getLogs` when checking deployments. Fixes CI issue.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A