### PR TITLE
Allow V3 action IDs without authorizer adaptor

### DIFF
--- a/action-ids/arbitrum/action-ids.json
+++ b/action-ids/arbitrum/action-ids.json
@@ -860,29 +860,29 @@
       }
     },
     "VaultExtension": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "approve(address,address,uint256)": "0xedba44a12a3f70ef9bd4081cca87202279d8f331f327987c63803f7eed621565",
-        "emitAuxiliaryEvent(bytes32,bytes)": "0x7f2238c8bc73ed89244945af97707b146b20dff798848bb298038071ecd00d18",
-        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x4029f25f9d7f607eb0216c84ad51aa79208f12df32c3104efdd0e9e3cfbcaa38",
-        "quote(bytes)": "0xe70327c8bd1eab2568e3cbc53635114c26c605227211db85ee83714a90597c42",
-        "quoteAndRevert(bytes)": "0xf22dea43faecbaf73748a24f1d0116e748ea694b7d6656597e91636477187b4d",
-        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x50118d2ca25ad62e8773e8f8cf2d852524ec84322d7d53de6276553ac18e4aea",
-        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xdf161cbff5b68e1194d92d0f6bce22bc50af94dcf8559bf25d7737034875465b"
+        "approve(address,address,uint256)": "0xe2698d2c010c562d530026a614d67fc90416d5672f5f9699efc78ca4bd089c62",
+        "emitAuxiliaryEvent(bytes32,bytes)": "0xcdac1c5a83ca5b07680832b86ed7ed0276ef4258580c7fe73bf16c7664ed408b",
+        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x6a12b6361b762769195238791276c0cb3d840e10be620bb362544275a2c70423",
+        "quote(bytes)": "0xc62780cd2227f2b4371c0fc003ad7b22b5659a6651df4a9de9e0bea54e9772d1",
+        "quoteAndRevert(bytes)": "0x3be38941153aeaef3e14c31e9f23924b93e86842141a6ff8f5f59324be566b07",
+        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x380e34ec1eb3440c2da270815979d4c3803d178081454bffb751105bdf5f83a0",
+        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xc48eacd28c0ebf0e8e0012c3f32de74207564dd445e0b36df1517ca01856c4b5"
       }
     },
     "Vault": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x3611bd6ae88cc0bf401f38dab06b8476b710eaa16291e4c42734e6acfd006dd8",
-        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0x4953352871abaff2408417c47b61303c76d9dd18a2bc74543b80856056b7a148",
-        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x2c1bc66a045f37b57ba757b276ad6b194d127b8e483f94e74ad91c9575337042",
-        "sendTo(address,address,uint256)": "0xd9e134664c97352a18de869922c521edb2baf3f39221d37ba9d7be5670efa211",
-        "settle(address,uint256)": "0x27abf6047fb026e94be2e1b01841cb58c2a0b96d09c8b65a69534a42445473bc",
-        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0x381e61e0a68937cd750f611771b3f7f182fb361ed3d89882493059d5414b4531",
-        "transfer(address,address,uint256)": "0x337eb6850c3a6ab343fd79dd01d270fd0187fd303c4241bd6b824f63787a9942",
-        "transferFrom(address,address,address,uint256)": "0x1b8878a384ca40db66da9df8ec98ac857744d49946c81514772582dbfe24fe04",
-        "unlock(bytes)": "0xbff62bffa0703647cd32fbc92052c16c80b5079e9e5ab8cb9fd1e98800fa1d05"
+        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x792ef3643259be92153b359b9c79dde2318e841a24976beae6cb8c61c809bb85",
+        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xe57bb1964c071ad7ba1c604268533c7899c5cdd871740b8c4f780a5c86ba5b6b",
+        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x0b261c520f4a1ff73e728c389a69078dc35c0fbfe4837fa1169dd89ed8259e14",
+        "sendTo(address,address,uint256)": "0xbb9c2c19bf6165b26469367ff647daa9fbb092c6b1aceb8aeb3fe410b01605d9",
+        "settle(address,uint256)": "0x52c2bd581f62bb99081d94342bb13b6e654d01a0696e94206438c957272c8fa6",
+        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0xc30d11c4e9e35f17d48b5e857d598cba172cf226a823d584066e2636de2cac6f",
+        "transfer(address,address,uint256)": "0x8899b66dc27fa35096627ada288e1fd3d1af3d2bd37352e6431090819bce7bf2",
+        "transferFrom(address,address,address,uint256)": "0x46bdb1914e2480bc86e502f93c887ae154eace91312fbd3362b73a80879558cc",
+        "unlock(bytes)": "0xd4836d9453603e68a44f9955680f7c023538529cd89ec5c8f154841e413d43f5"
       }
     }
   },

--- a/action-ids/avalanche/action-ids.json
+++ b/action-ids/avalanche/action-ids.json
@@ -473,29 +473,29 @@
       }
     },
     "VaultExtension": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "approve(address,address,uint256)": "0x80b06d2746e21ff8f646097f05bab17b19ac156bda8cd6f749085b00e8431120",
-        "emitAuxiliaryEvent(bytes32,bytes)": "0xb338314b2be8e96f3972326c98f6905524a435651ac9f9f5c6ce217140ad9999",
-        "initialize(address,address,address[],uint256[],uint256,bytes)": "0xb5e4682c52dbbbd1d279315d4f83382459b659f4a4bedf812c55dc56d552b4e9",
-        "quote(bytes)": "0xeb867878dba536046a2870e6b57d0bd3c7a72ab3c2e62ffe693392f236a4584e",
-        "quoteAndRevert(bytes)": "0xf412640f80a028a0e03ff54d61d625889b433f26bf5f27cdb88094bf03eae23c",
-        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x38f10a7b9df77b3e8d913660592fce0a46894c20a0ea9a240ead3a35a53e7e2f",
-        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xdbef54d1334f6d2a07368a172f50a1b1c821d65c040dcbe1f54a595e7aa09fb6"
+        "approve(address,address,uint256)": "0xe2698d2c010c562d530026a614d67fc90416d5672f5f9699efc78ca4bd089c62",
+        "emitAuxiliaryEvent(bytes32,bytes)": "0xcdac1c5a83ca5b07680832b86ed7ed0276ef4258580c7fe73bf16c7664ed408b",
+        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x6a12b6361b762769195238791276c0cb3d840e10be620bb362544275a2c70423",
+        "quote(bytes)": "0xc62780cd2227f2b4371c0fc003ad7b22b5659a6651df4a9de9e0bea54e9772d1",
+        "quoteAndRevert(bytes)": "0x3be38941153aeaef3e14c31e9f23924b93e86842141a6ff8f5f59324be566b07",
+        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x380e34ec1eb3440c2da270815979d4c3803d178081454bffb751105bdf5f83a0",
+        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xc48eacd28c0ebf0e8e0012c3f32de74207564dd445e0b36df1517ca01856c4b5"
       }
     },
     "Vault": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x78a692adf133d997eb6a0b75a61fcf86a0a331086a6b91ee7a18d60cdf31aa75",
-        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xbc01156aaf41e0d0bc2d751559832c6d937ab0344d110cebf91f66b5de336a4d",
-        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0xb065946617568f552747878adfceb3b24ab1fdbb586eb6ca45b533106a28a644",
-        "sendTo(address,address,uint256)": "0x9dee55f44ee390444f709e153ba4d1a1476fea135cc6da87e9c28f6110a91f03",
-        "settle(address,uint256)": "0xd7589d60a13d740c85b65d3282baaf73c48f6aa79dd6276f934344dc498a6c89",
-        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0x210f16acf789f4c2e2fc59e13e20696d208857b73fc6bb0cbf60bfab668cb8ee",
-        "transfer(address,address,uint256)": "0xa0bb0a1dc6b7746c8e919be19772cd1b072df499dbf79b5626172a797d2684b7",
-        "transferFrom(address,address,address,uint256)": "0x52279a7e93cc6506a01486c5ca342e1265e95af539b26773553a02de04feb28e",
-        "unlock(bytes)": "0x0b54fbb63e7e95749fcfeef46d9897553bd864acea4f5ac8d465f87a8803ff3c"
+        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x792ef3643259be92153b359b9c79dde2318e841a24976beae6cb8c61c809bb85",
+        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xe57bb1964c071ad7ba1c604268533c7899c5cdd871740b8c4f780a5c86ba5b6b",
+        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x0b261c520f4a1ff73e728c389a69078dc35c0fbfe4837fa1169dd89ed8259e14",
+        "sendTo(address,address,uint256)": "0xbb9c2c19bf6165b26469367ff647daa9fbb092c6b1aceb8aeb3fe410b01605d9",
+        "settle(address,uint256)": "0x52c2bd581f62bb99081d94342bb13b6e654d01a0696e94206438c957272c8fa6",
+        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0xc30d11c4e9e35f17d48b5e857d598cba172cf226a823d584066e2636de2cac6f",
+        "transfer(address,address,uint256)": "0x8899b66dc27fa35096627ada288e1fd3d1af3d2bd37352e6431090819bce7bf2",
+        "transferFrom(address,address,address,uint256)": "0x46bdb1914e2480bc86e502f93c887ae154eace91312fbd3362b73a80879558cc",
+        "unlock(bytes)": "0xd4836d9453603e68a44f9955680f7c023538529cd89ec5c8f154841e413d43f5"
       }
     }
   },

--- a/action-ids/base/action-ids.json
+++ b/action-ids/base/action-ids.json
@@ -425,29 +425,29 @@
       }
     },
     "VaultExtension": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "approve(address,address,uint256)": "0x6bbf12aa565ff6c84353f210e17268f8ea6639cccf7194073e6d74f086b97000",
-        "emitAuxiliaryEvent(bytes32,bytes)": "0x837f746ab418e7785c40422c09dbfea8e727b146ad7e836ea4e847fdec761c64",
-        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x9f539c6a9e4871328a3c06fe21676ec67203e2b2c174b966100a03ba270efa39",
-        "quote(bytes)": "0xdb68dd8278276d92e18d8d26016c7b5179a866272d46f6c5b8898fec9c7887f5",
-        "quoteAndRevert(bytes)": "0x6ee1e523f52105b0567e52ed88f67b6cd6bc378e5783bd0f3b8929b6efee54fe",
-        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0xe68a37c3b11c7ceb205f46ecc77cc512537c822649cd74c5df9af3a84e079972",
-        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0x25912d923c03b9b66378c9ba280e1bf51b94e9da9934fdb9d125d7d1d12fb184"
+        "approve(address,address,uint256)": "0xe2698d2c010c562d530026a614d67fc90416d5672f5f9699efc78ca4bd089c62",
+        "emitAuxiliaryEvent(bytes32,bytes)": "0xcdac1c5a83ca5b07680832b86ed7ed0276ef4258580c7fe73bf16c7664ed408b",
+        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x6a12b6361b762769195238791276c0cb3d840e10be620bb362544275a2c70423",
+        "quote(bytes)": "0xc62780cd2227f2b4371c0fc003ad7b22b5659a6651df4a9de9e0bea54e9772d1",
+        "quoteAndRevert(bytes)": "0x3be38941153aeaef3e14c31e9f23924b93e86842141a6ff8f5f59324be566b07",
+        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x380e34ec1eb3440c2da270815979d4c3803d178081454bffb751105bdf5f83a0",
+        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xc48eacd28c0ebf0e8e0012c3f32de74207564dd445e0b36df1517ca01856c4b5"
       }
     },
     "Vault": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x85b6c5f82e3d081f02e06c9edfee92b957ad844b3886b1e0d0c65b2cf001ab1e",
-        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xbce9678b3d1487fb8beba027b040634fdd85ab72969c59c57c78097aaadd934a",
-        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x50d74a1e52d2c23e5828f57a6cd6cb68ae1f8a5b69822c9fb7622a561c746373",
-        "sendTo(address,address,uint256)": "0x9fb41bda3a987208a145532cab44fdcc75f8c37bea367259f3d2ba55d5929f71",
-        "settle(address,uint256)": "0xae966c73166476df3b5a2d820c4f80b79b215066d429a9fb43687e6864dbed0d",
-        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0x522e6399785678c8aa3415c42bbb1725321b9664a086f3c347b248351f332e3d",
-        "transfer(address,address,uint256)": "0xf5c964a7c7527191ed7d1494e7e942a4b5bbdb04a109114bbc1da5272abfb8af",
-        "transferFrom(address,address,address,uint256)": "0x551246041d1e4d62ed6eed31d0dcc9d4c4375275696fb83ee7d337948e671eff",
-        "unlock(bytes)": "0x8c11c71f568d8ba2b522f9b1b97e238a81b4dad4e9bddae52496c1df5b6f72c2"
+        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x792ef3643259be92153b359b9c79dde2318e841a24976beae6cb8c61c809bb85",
+        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xe57bb1964c071ad7ba1c604268533c7899c5cdd871740b8c4f780a5c86ba5b6b",
+        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x0b261c520f4a1ff73e728c389a69078dc35c0fbfe4837fa1169dd89ed8259e14",
+        "sendTo(address,address,uint256)": "0xbb9c2c19bf6165b26469367ff647daa9fbb092c6b1aceb8aeb3fe410b01605d9",
+        "settle(address,uint256)": "0x52c2bd581f62bb99081d94342bb13b6e654d01a0696e94206438c957272c8fa6",
+        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0xc30d11c4e9e35f17d48b5e857d598cba172cf226a823d584066e2636de2cac6f",
+        "transfer(address,address,uint256)": "0x8899b66dc27fa35096627ada288e1fd3d1af3d2bd37352e6431090819bce7bf2",
+        "transferFrom(address,address,address,uint256)": "0x46bdb1914e2480bc86e502f93c887ae154eace91312fbd3362b73a80879558cc",
+        "unlock(bytes)": "0xd4836d9453603e68a44f9955680f7c023538529cd89ec5c8f154841e413d43f5"
       }
     }
   },

--- a/action-ids/gnosis/action-ids.json
+++ b/action-ids/gnosis/action-ids.json
@@ -537,29 +537,29 @@
       }
     },
     "Vault": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x6c4756eb2279dc89a5002b942b3ecd827e09443ec00903b38396c1f719ec888f",
-        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0x705da14f338d2ee2e1e4ccba7299b3aa6d91a4866367ba30c3061e18cca32f4d",
-        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0xaf94851e3e3cd09ff304ffead78354e597014723e6a4199ff18534e554df6cdf",
-        "sendTo(address,address,uint256)": "0x20cdf5376a6e760b6026076b5e361686e9530f325a2e60b57dc08a7dc6129497",
-        "settle(address,uint256)": "0xfcd914d755816d8fc2f78368b31503891adaba47c6a43988e39de366c62b9515",
-        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0xec2e246fcb8a0b6ef57463283f3e6a08f518ad214165993aa458c886a61bf022",
-        "transfer(address,address,uint256)": "0x4e20f6e5d4963989880fdc4ef36111eaab7c0da2f286445943e567778bdc1bb5",
-        "transferFrom(address,address,address,uint256)": "0x39c091281d65d497cebcb01c8cd68de57ae7cee0d1496fcb9f813c5e784c36ac",
-        "unlock(bytes)": "0x879aba5abe16844b2b62cca7135b92c360e35670e374a7345a787cbf969f2a41"
+        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x792ef3643259be92153b359b9c79dde2318e841a24976beae6cb8c61c809bb85",
+        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xe57bb1964c071ad7ba1c604268533c7899c5cdd871740b8c4f780a5c86ba5b6b",
+        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x0b261c520f4a1ff73e728c389a69078dc35c0fbfe4837fa1169dd89ed8259e14",
+        "sendTo(address,address,uint256)": "0xbb9c2c19bf6165b26469367ff647daa9fbb092c6b1aceb8aeb3fe410b01605d9",
+        "settle(address,uint256)": "0x52c2bd581f62bb99081d94342bb13b6e654d01a0696e94206438c957272c8fa6",
+        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0xc30d11c4e9e35f17d48b5e857d598cba172cf226a823d584066e2636de2cac6f",
+        "transfer(address,address,uint256)": "0x8899b66dc27fa35096627ada288e1fd3d1af3d2bd37352e6431090819bce7bf2",
+        "transferFrom(address,address,address,uint256)": "0x46bdb1914e2480bc86e502f93c887ae154eace91312fbd3362b73a80879558cc",
+        "unlock(bytes)": "0xd4836d9453603e68a44f9955680f7c023538529cd89ec5c8f154841e413d43f5"
       }
     },
     "VaultExtension": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "approve(address,address,uint256)": "0xd72e8165037d4a1a52145c9d4ebae3fce89228db9354c308d5c4f208eaa62b9a",
-        "emitAuxiliaryEvent(bytes32,bytes)": "0x0c13b44d961be6d8b68a2bc200332864c03662bfc5ca8162f940ba5e3e32ab31",
-        "initialize(address,address,address[],uint256[],uint256,bytes)": "0xfcae4fc78f98bb7ebf3a2bcafce622bb6f96ee9043c513bb461d09250e27c5cc",
-        "quote(bytes)": "0xd10b1cddb5573f2bd028680a1945bc4e622a9851b04ea4f60bd2b8e4f42daf3c",
-        "quoteAndRevert(bytes)": "0x1ce1d98ba871520be2c725f462b2f6a878a0c84624907e0704ab7462fc7a3946",
-        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0xf880efcbfc7d2ec4135528966c076c787cc11e5ba4e69564ede45904812c4a75",
-        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0x5d89495614df458079b29a44779b48f655c441c2d8ee476a947b365b6b348863"
+        "approve(address,address,uint256)": "0xe2698d2c010c562d530026a614d67fc90416d5672f5f9699efc78ca4bd089c62",
+        "emitAuxiliaryEvent(bytes32,bytes)": "0xcdac1c5a83ca5b07680832b86ed7ed0276ef4258580c7fe73bf16c7664ed408b",
+        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x6a12b6361b762769195238791276c0cb3d840e10be620bb362544275a2c70423",
+        "quote(bytes)": "0xc62780cd2227f2b4371c0fc003ad7b22b5659a6651df4a9de9e0bea54e9772d1",
+        "quoteAndRevert(bytes)": "0x3be38941153aeaef3e14c31e9f23924b93e86842141a6ff8f5f59324be566b07",
+        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x380e34ec1eb3440c2da270815979d4c3803d178081454bffb751105bdf5f83a0",
+        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xc48eacd28c0ebf0e8e0012c3f32de74207564dd445e0b36df1517ca01856c4b5"
       }
     },
     "VaultAdmin": {

--- a/action-ids/mainnet/action-ids.json
+++ b/action-ids/mainnet/action-ids.json
@@ -1530,29 +1530,29 @@
       }
     },
     "Vault": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x256cbf3e8997d5400cc8a8728d60a57434aadcef3640611a4ed6e394bb3bd861",
-        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0x838f4d825f5ade7523212fbceeb66c495a4d882e4a16ff3f4a97c2ff05bf7144",
-        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x2a02431e144e206a21be68f5d376059ef4778ab124c6ce0018a4879bf7211860",
-        "sendTo(address,address,uint256)": "0x5cfbaf85aad7af032e8afb72f244f9bb7063e1f585615162fc4ad89ea4f478d4",
-        "settle(address,uint256)": "0x24c72b5fda9f66b68801657134b6bbae624f81f1fbf8047364cad94351eaa96e",
-        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0x8d70be408797c9e764716578bdca3310a0366040ff0264af4a706f5dc7ae0b41",
-        "transfer(address,address,uint256)": "0x6188d73e0b6eb70068b36e5a214d80d33a0b51df21d45229b60d2d8a687f27b4",
-        "transferFrom(address,address,address,uint256)": "0x17341aae596fedd1eafe97637eff96261a1de19f86b90bc8f0f9d6e7f43b62e5",
-        "unlock(bytes)": "0xba0e235841f54b109397404a85edabc9a1e2eb8fffabcd25a704d3b918ffdf6a"
+        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x792ef3643259be92153b359b9c79dde2318e841a24976beae6cb8c61c809bb85",
+        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xe57bb1964c071ad7ba1c604268533c7899c5cdd871740b8c4f780a5c86ba5b6b",
+        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x0b261c520f4a1ff73e728c389a69078dc35c0fbfe4837fa1169dd89ed8259e14",
+        "sendTo(address,address,uint256)": "0xbb9c2c19bf6165b26469367ff647daa9fbb092c6b1aceb8aeb3fe410b01605d9",
+        "settle(address,uint256)": "0x52c2bd581f62bb99081d94342bb13b6e654d01a0696e94206438c957272c8fa6",
+        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0xc30d11c4e9e35f17d48b5e857d598cba172cf226a823d584066e2636de2cac6f",
+        "transfer(address,address,uint256)": "0x8899b66dc27fa35096627ada288e1fd3d1af3d2bd37352e6431090819bce7bf2",
+        "transferFrom(address,address,address,uint256)": "0x46bdb1914e2480bc86e502f93c887ae154eace91312fbd3362b73a80879558cc",
+        "unlock(bytes)": "0xd4836d9453603e68a44f9955680f7c023538529cd89ec5c8f154841e413d43f5"
       }
     },
     "VaultExtension": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "approve(address,address,uint256)": "0x3b5eb876826de88a392c5210673893efe2b34d80a0132920d9f18927755b9ae9",
-        "emitAuxiliaryEvent(bytes32,bytes)": "0x122578e9799f960f2ca8831cb3ec8c00c956f83b05cccdd2ca29d09df6384670",
-        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x137821d4f0431d9418e6dbeac8f85d2b2932e4551b154b65e55f768c67bc8fcb",
-        "quote(bytes)": "0xebbf2db6272eb8f7da19da6a18a64e5d867c9e3d10536d2c079d5472b2848f4d",
-        "quoteAndRevert(bytes)": "0x4e038a4f8719eff5566bc2132d225d7fa506fc8989001b8fc52b1d0e3ff39dad",
-        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x925747790b98f2621935a143937da35306d7c5ce25fad10df2fe06787f989469",
-        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xda67b2c3b008763a97ca9869789e14570d6abe53d1d6659ee8d62917bbddc730"
+        "approve(address,address,uint256)": "0xe2698d2c010c562d530026a614d67fc90416d5672f5f9699efc78ca4bd089c62",
+        "emitAuxiliaryEvent(bytes32,bytes)": "0xcdac1c5a83ca5b07680832b86ed7ed0276ef4258580c7fe73bf16c7664ed408b",
+        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x6a12b6361b762769195238791276c0cb3d840e10be620bb362544275a2c70423",
+        "quote(bytes)": "0xc62780cd2227f2b4371c0fc003ad7b22b5659a6651df4a9de9e0bea54e9772d1",
+        "quoteAndRevert(bytes)": "0x3be38941153aeaef3e14c31e9f23924b93e86842141a6ff8f5f59324be566b07",
+        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x380e34ec1eb3440c2da270815979d4c3803d178081454bffb751105bdf5f83a0",
+        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xc48eacd28c0ebf0e8e0012c3f32de74207564dd445e0b36df1517ca01856c4b5"
       }
     },
     "VaultAdmin": {

--- a/action-ids/optimism/action-ids.json
+++ b/action-ids/optimism/action-ids.json
@@ -778,29 +778,29 @@
       }
     },
     "VaultExtension": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "approve(address,address,uint256)": "0x3b5eb876826de88a392c5210673893efe2b34d80a0132920d9f18927755b9ae9",
-        "emitAuxiliaryEvent(bytes32,bytes)": "0x122578e9799f960f2ca8831cb3ec8c00c956f83b05cccdd2ca29d09df6384670",
-        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x137821d4f0431d9418e6dbeac8f85d2b2932e4551b154b65e55f768c67bc8fcb",
-        "quote(bytes)": "0xebbf2db6272eb8f7da19da6a18a64e5d867c9e3d10536d2c079d5472b2848f4d",
-        "quoteAndRevert(bytes)": "0x4e038a4f8719eff5566bc2132d225d7fa506fc8989001b8fc52b1d0e3ff39dad",
-        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x925747790b98f2621935a143937da35306d7c5ce25fad10df2fe06787f989469",
-        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xda67b2c3b008763a97ca9869789e14570d6abe53d1d6659ee8d62917bbddc730"
+        "approve(address,address,uint256)": "0xe2698d2c010c562d530026a614d67fc90416d5672f5f9699efc78ca4bd089c62",
+        "emitAuxiliaryEvent(bytes32,bytes)": "0xcdac1c5a83ca5b07680832b86ed7ed0276ef4258580c7fe73bf16c7664ed408b",
+        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x6a12b6361b762769195238791276c0cb3d840e10be620bb362544275a2c70423",
+        "quote(bytes)": "0xc62780cd2227f2b4371c0fc003ad7b22b5659a6651df4a9de9e0bea54e9772d1",
+        "quoteAndRevert(bytes)": "0x3be38941153aeaef3e14c31e9f23924b93e86842141a6ff8f5f59324be566b07",
+        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x380e34ec1eb3440c2da270815979d4c3803d178081454bffb751105bdf5f83a0",
+        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xc48eacd28c0ebf0e8e0012c3f32de74207564dd445e0b36df1517ca01856c4b5"
       }
     },
     "Vault": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x256cbf3e8997d5400cc8a8728d60a57434aadcef3640611a4ed6e394bb3bd861",
-        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0x838f4d825f5ade7523212fbceeb66c495a4d882e4a16ff3f4a97c2ff05bf7144",
-        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x2a02431e144e206a21be68f5d376059ef4778ab124c6ce0018a4879bf7211860",
-        "sendTo(address,address,uint256)": "0x5cfbaf85aad7af032e8afb72f244f9bb7063e1f585615162fc4ad89ea4f478d4",
-        "settle(address,uint256)": "0x24c72b5fda9f66b68801657134b6bbae624f81f1fbf8047364cad94351eaa96e",
-        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0x8d70be408797c9e764716578bdca3310a0366040ff0264af4a706f5dc7ae0b41",
-        "transfer(address,address,uint256)": "0x6188d73e0b6eb70068b36e5a214d80d33a0b51df21d45229b60d2d8a687f27b4",
-        "transferFrom(address,address,address,uint256)": "0x17341aae596fedd1eafe97637eff96261a1de19f86b90bc8f0f9d6e7f43b62e5",
-        "unlock(bytes)": "0xba0e235841f54b109397404a85edabc9a1e2eb8fffabcd25a704d3b918ffdf6a"
+        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x792ef3643259be92153b359b9c79dde2318e841a24976beae6cb8c61c809bb85",
+        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xe57bb1964c071ad7ba1c604268533c7899c5cdd871740b8c4f780a5c86ba5b6b",
+        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x0b261c520f4a1ff73e728c389a69078dc35c0fbfe4837fa1169dd89ed8259e14",
+        "sendTo(address,address,uint256)": "0xbb9c2c19bf6165b26469367ff647daa9fbb092c6b1aceb8aeb3fe410b01605d9",
+        "settle(address,uint256)": "0x52c2bd581f62bb99081d94342bb13b6e654d01a0696e94206438c957272c8fa6",
+        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0xc30d11c4e9e35f17d48b5e857d598cba172cf226a823d584066e2636de2cac6f",
+        "transfer(address,address,uint256)": "0x8899b66dc27fa35096627ada288e1fd3d1af3d2bd37352e6431090819bce7bf2",
+        "transferFrom(address,address,address,uint256)": "0x46bdb1914e2480bc86e502f93c887ae154eace91312fbd3362b73a80879558cc",
+        "unlock(bytes)": "0xd4836d9453603e68a44f9955680f7c023538529cd89ec5c8f154841e413d43f5"
       }
     }
   },

--- a/action-ids/sepolia/action-ids.json
+++ b/action-ids/sepolia/action-ids.json
@@ -643,29 +643,29 @@
       }
     },
     "Vault": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x9134836b6821defde6268123ce08194026b8a342b73e11eef2686dd760cafe10",
-        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xb4ca54a4a5a58d80eb7447ece1bde99a5b742bdd05c962595b0716b4efd74b93",
-        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x1c62cc8a60ebc6946083e358576b40f1b4fcc36f770c24a8fe41d49ab4c6e402",
-        "sendTo(address,address,uint256)": "0xbcff410ca52e22f27d304febd63c3a0a0d1890e67d1537606e0f7a1367381bb2",
-        "settle(address,uint256)": "0x12aaeed2d54eccb24da68a83e1b0c9ed70f6dfd7a875733179a267d6547226fc",
-        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0xe359d81c7f342589b99256c4cb0461acd0d64714b65e3c1b158093c24395aba9",
-        "transfer(address,address,uint256)": "0x33a1fcb7e1aaa35c6d2b911a60ea9153ff15f82308030988538e224927b73bd5",
-        "transferFrom(address,address,address,uint256)": "0x605e9fe01e174baee625f0fa04f253d4e265b37279c199e2cea8b27d30f8b805",
-        "unlock(bytes)": "0x9ee17b9874b9947ff7561a7bdb5c64c086fcf34dc63d7c4319aba498c0088901"
+        "addLiquidity((address,address,uint256[],uint256,uint8,bytes))": "0x792ef3643259be92153b359b9c79dde2318e841a24976beae6cb8c61c809bb85",
+        "erc4626BufferWrapOrUnwrap((uint8,uint8,address,uint256,uint256))": "0xe57bb1964c071ad7ba1c604268533c7899c5cdd871740b8c4f780a5c86ba5b6b",
+        "removeLiquidity((address,address,uint256,uint256[],uint8,bytes))": "0x0b261c520f4a1ff73e728c389a69078dc35c0fbfe4837fa1169dd89ed8259e14",
+        "sendTo(address,address,uint256)": "0xbb9c2c19bf6165b26469367ff647daa9fbb092c6b1aceb8aeb3fe410b01605d9",
+        "settle(address,uint256)": "0x52c2bd581f62bb99081d94342bb13b6e654d01a0696e94206438c957272c8fa6",
+        "swap((uint8,address,address,address,uint256,uint256,bytes))": "0xc30d11c4e9e35f17d48b5e857d598cba172cf226a823d584066e2636de2cac6f",
+        "transfer(address,address,uint256)": "0x8899b66dc27fa35096627ada288e1fd3d1af3d2bd37352e6431090819bce7bf2",
+        "transferFrom(address,address,address,uint256)": "0x46bdb1914e2480bc86e502f93c887ae154eace91312fbd3362b73a80879558cc",
+        "unlock(bytes)": "0xd4836d9453603e68a44f9955680f7c023538529cd89ec5c8f154841e413d43f5"
       }
     },
     "VaultExtension": {
-      "useAdaptor": true,
+      "useAdaptor": false,
       "actionIds": {
-        "approve(address,address,uint256)": "0xaa772b3cc4deced0b0d6fe6a4e4b365c949a47537b56a8d91ab38387a48192c8",
-        "emitAuxiliaryEvent(bytes32,bytes)": "0xe9adb43c3552fd50b28c4433091f0262463d25463800dca844fec8cce100d389",
-        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x6fb19fa2eb71e96da9f30f380118a45a2df5dae2239064f8f177fdee2f88320a",
-        "quote(bytes)": "0x6f29bc2aab00457c17f15e2c37de63aa31991c7d77f5ca333601d3441a544c48",
-        "quoteAndRevert(bytes)": "0xcdbf3f3d4bb825c251ce169f37e515e511128030ae2895112fc76776b732af07",
-        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0xdecaaef80fafe64ea53eb902fe77c66b8c77f5313b391be8813c25dd067b97b0",
-        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xf6a24239698567a5710905114172ee46c32ff1a2cfc0eb91929e8aecc7cecde2"
+        "approve(address,address,uint256)": "0xe2698d2c010c562d530026a614d67fc90416d5672f5f9699efc78ca4bd089c62",
+        "emitAuxiliaryEvent(bytes32,bytes)": "0xcdac1c5a83ca5b07680832b86ed7ed0276ef4258580c7fe73bf16c7664ed408b",
+        "initialize(address,address,address[],uint256[],uint256,bytes)": "0x6a12b6361b762769195238791276c0cb3d840e10be620bb362544275a2c70423",
+        "quote(bytes)": "0xc62780cd2227f2b4371c0fc003ad7b22b5659a6651df4a9de9e0bea54e9772d1",
+        "quoteAndRevert(bytes)": "0x3be38941153aeaef3e14c31e9f23924b93e86842141a6ff8f5f59324be566b07",
+        "registerPool(address,(address,uint8,address,bool)[],uint256,uint32,bool,(address,address,address),address,(bool,bool,bool,bool))": "0x380e34ec1eb3440c2da270815979d4c3803d178081454bffb751105bdf5f83a0",
+        "removeLiquidityRecovery(address,address,uint256,uint256[])": "0xc48eacd28c0ebf0e8e0012c3f32de74207564dd445e0b36df1517ca01856c4b5"
       }
     },
     "VaultAdmin": {

--- a/src/task.ts
+++ b/src/task.ts
@@ -94,6 +94,16 @@ export default class Task {
     return this.instanceAt(name, address);
   }
 
+  async optionalDeployedInstance(name: string): Promise<Contract | undefined> {
+    let instance: Contract;
+    try {
+      instance = await this.deployedInstance(name);
+      return instance;
+    } catch {
+      return undefined;
+    }
+  }
+
   async inputInstance(artifactName: string, inputName: string): Promise<Contract> {
     const rawInput = this.rawInput();
     const input = rawInput[inputName];


### PR DESCRIPTION
# Description

We are starting to deploy to chains that don't have V2 and the authorizer adaptor.
Action ID generation defaults to the adaptor whenever there's no `actionId` method in the contracts, which is not really accurate for V3 contracts. This PR allows skipping those cases.

V3 vault is a bit of a special case, because `Vault` and `VaultExtension` really are authorizer aware via the proxy pattern. Truth is that this PR doesn't really change anything as every method in vault and vault extension are actually permissionless, but it's not technically correct to use the adaptor in that case (even when it's available).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A