### PR TITLE
Fix docs and remove expired boost

### DIFF
--- a/v2/deprecated/20221205-veboost-v2/readme.md
+++ b/v2/deprecated/20221205-veboost-v2/readme.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **DEPRECATED: do not use** ⚠️
 >
-> This deployment was deprecated in favor of a new 2.1 version that is semantically equivalent, but allows migrating from this contract, and grants infinite approval to designated operators for the Stake DAO and Tetu BAL lockers: [composable-stable-pool-v3](../../tasks/20250613-veboost-v2.1/)
+> This deployment was deprecated in favor of a new 2.1 version that is semantically equivalent, but allows migrating from this contract, and grants infinite approval to designated operators for the Stake DAO and Tetu BAL lockers: [veboost-v2.1](../../tasks/20250613-veboost-v2.1/)
 
 Deployment of the veBoostV2, a replacement for the [`PreseededVotingEscrowDelegation`](../../tasks/20220530-preseeded-voting-escrow-delegation). This simplifies the boost contract greatly and allows integration with [Paladin's](https://paladin.vote/) boost market.
 

--- a/v2/tasks/20250613-veboost-v2.1/input.ts
+++ b/v2/tasks/20250613-veboost-v2.1/input.ts
@@ -51,14 +51,6 @@ export default {
         // start_time: 1724977943,
         end_time: 1753920000, // 7/31/25
       },
-      {
-        // tx: 0x148b4ad2b40f6f10dec822c523fdc109d605d398049cbeddad375a2b99ae0aca
-        from: '0x278a8453ECf2f477a5Ab3Cd9b0Ea410b7B2C4182',
-        to: '0xea79d1A83Da6DB43a85942767C389fE0ACf336A5',
-        // amount: bn('19747907203562458212'),
-        // start_time: 1719216503,
-        end_time: 1750291200, // 6/19/25
-      },
     ],
     PreseededApprovalCalls: [
       {

--- a/v2/tasks/20250613-veboost-v2.1/input.ts
+++ b/v2/tasks/20250613-veboost-v2.1/input.ts
@@ -28,14 +28,6 @@ export default {
     // Amounts and start times included for reference.
     PreseededBoostCalls: [
       {
-        // tx: 0xb1795fffafd3741569d1d4d348483938c018034c65e4415056d4a18a4da1601b
-        from: '0x250Dc31d9eCD8AF562f506b40d0dE4349C987E92',
-        to: '0xea79d1A83Da6DB43a85942767C389fE0ACf336A5',
-        // amount: bn('9575170789062471648420'),
-        // start_time: 1748360315,
-        end_time: 1750896000, // 6/26/25
-      },
-      {
         // tx: 0x494930339e854d855b9d96f940a8535d86fc0bbc586847713a4d168ff43270f3
         from: '0x6d7003C9366AdCE15433090a5179157995bff620',
         to: '0xea79d1A83Da6DB43a85942767C389fE0ACf336A5',


### PR DESCRIPTION
# Description

The veBoost v2.1 migration will tolerate "expired" boosts, so this isn't strictly necessary, but one has already expired (6/19), and the 6/26 one will surely expire before execution, as it's only three days away, and the proposal isn't even published yet.

There is also a typo in the previously merged docs, so might as well fix both.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
