### PR TITLE
Change block explorer for hyperevm to etherscan

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -515,8 +515,8 @@ export default {
         network: 'hyperevm',
         chainId: 999,
         urls: {
-          apiURL: 'https://www.hyperscan.com/api',
-          browserURL: 'https://www.hyperscan.com',
+          apiURL: 'https://api.etherscan.io/v2/api?chainid=999',
+          browserURL: 'https://hyperevmscan.io/',
         },
       },
     ],


### PR DESCRIPTION
# Description

This is a test for the multichain API V2.
Most of the contracts were already verified in hyperevm-etherscan, and I could verify a few more using this.
However, I still get weird errors despite the success (it says chain ID is not present even though it's there). Still, this would be an example to migrate the etherscan API [from v1 to v2](https://docs.etherscan.io/etherscan-v2/v2-quickstart).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A