### PR TITLE
Add `--v1` flag to deploy and verify tasks to support Etherscan V1 API

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -36,6 +36,7 @@ import {
   withRetries,
 } from './src/network';
 import { Etherscan } from '@nomicfoundation/hardhat-verify/etherscan';
+import { ApiKey } from '@nomicfoundation/hardhat-verify/types';
 
 const THEGRAPHURLS: { [key: string]: string } = {};
 
@@ -43,12 +44,25 @@ task('deploy', 'Run deployment task')
   .addParam('id', 'Deployment task ID')
   .addFlag('force', 'Ignore previous deployments')
   .addOptionalParam('key', 'Etherscan API key to verify contracts')
+  .addFlag('v1', 'Use Etherscan V1 API to verify the contract')
   .setAction(
-    async (args: { id: string; force?: boolean; key?: string; verbose?: boolean }, hre: HardhatRuntimeEnvironment) => {
+    async (
+      args: { id: string; force?: boolean; key?: string; verbose?: boolean; v1?: boolean },
+      hre: HardhatRuntimeEnvironment
+    ) => {
       Logger.setDefaults(false, args.verbose || false);
 
+      const network = hre.network.name;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const apiKey = args.key ?? (hre.config.networks[hre.network.name] as any).verificationAPIKey;
+      const networkApiKey = args.key ?? (hre.config.networks[network] as any).verificationAPIKey;
+      // If the v1 API flag is set, we need to wrap the API key in an object with the network name as the key
+      // as this is how the Etherscan verification library expects it (otherwise it defaults to v2).
+      const apiKey: ApiKey = args.v1
+        ? {
+            [network]: networkApiKey,
+          }
+        : networkApiKey;
+
       const verifier = apiKey
         ? new Verifier(
             hre.network,
@@ -70,15 +84,25 @@ task('verify-contract', `Verify a task's deployment on a block explorer`)
   .addParam('address', 'Contract address')
   .addParam('args', 'ABI-encoded constructor arguments')
   .addOptionalParam('key', 'Etherscan API key to verify contracts')
+  .addFlag('v1', 'Use Etherscan V1 API to verify the contract')
   .setAction(
     async (
-      args: { id: string; name: string; address: string; key: string; args: string; verbose?: boolean },
+      args: { id: string; name: string; address: string; key: string; args: string; verbose?: boolean; v1?: boolean },
       hre: HardhatRuntimeEnvironment
     ) => {
       Logger.setDefaults(false, args.verbose || false);
 
+      const network = hre.network.name;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const apiKey = args.key ?? (hre.config.networks[hre.network.name] as any).verificationAPIKey;
+      const networkApiKey = args.key ?? (hre.config.networks[network] as any).verificationAPIKey;
+      // If the v1 API flag is set, we need to wrap the API key in an object with the network name as the key
+      // as this is how the Etherscan verification library expects it (otherwise it defaults to v2).
+      const apiKey: ApiKey = args.v1
+        ? {
+            [network]: networkApiKey,
+          }
+        : networkApiKey;
+
       const verifier = apiKey
         ? new Verifier(
             hre.network,


### PR DESCRIPTION
# Description

Etherscan deprecated its V1 API some time ago, and we had to update `hardhat-verify` as indicated in this PR's description: https://github.com/balancer/balancer-deployments/pull/311. The problem back then was that the most common explorers stopped verifying contracts (e.g. etherscan, arbiscan, etc), and the update did the trick.

The problem is that non-etherscan based explorers still use the old API, and using the new one results in an error: 
```
HardhatVerifyError: Missing or unsupported chainid parameter (required for v2 api), please see https://api.etherscan.io/v2/chainlist for the list of supported chainids
```

This happens in Plasma / XLayer for example. Those two chain IDs are not in the list. In the case of Plasma, contract verification still succeeded for contracts deployed to other networks (but probably because the explorer was taking the code from them directly).

I haven't tried Plasma yet, but for XLayer I found that reverting the library worked. Digging a bit, I found that the old API still works (as long as the URL is properly configured in the hardhat config of course).

The issue boils down to [this line](https://github.com/NomicFoundation/hardhat/blob/%40nomicfoundation/hardhat-verify%402.1.2/packages/hardhat-verify/src/internal/etherscan.ts#L93), where the newer versions of `hardhat-verify` decide which API to use. We were always sending strings, so it defaulted to V2.

This PR adds a flag to manually choose which one to use, by changing the format used to pass along the API key (record vs plain string). I've already tested it (see [here for example](https://www.oklink.com/x-layer/address/0xf24917fb88261a37cc57f686ebc831a5c0b9fd39/contract)), and it keeps our code compatible with etherscan based explorers using V2 API.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A