### PR TITLE
Actions: Network cache fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           path: 'src/helpers/.hardhat/cache/hardhat-network-fork/**'
           key: hardhat-network-fork-${{ github.run_number }}-${{ github.run_attempt }}
           restore-keys: |
-            hardhat-network-fork-*
+            hardhat-network-fork-
       - name: Prepare Config
         run: yarn ci:prepare-config
         env:


### PR DESCRIPTION
# Description

Fix CI cache, using standard github actions. The existing action was throwing some 400 errors, making the subsequent runs slower and more demanding for the RPCs.

This PR replaces the custom action to save the cache always (and it saves only when there's a difference). See [here](https://github.com/actions/cache/tree/main/save#always-save-cache) and [here](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching) for reference.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #339 