### PR TITLE
Address remaining linkspector issue

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -13,13 +13,7 @@ httpHeaders:
       Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
       Accept-Language: 'en-US,en;q=0.5'
 
-  - url:
-      - https://www.npmjs.com/
-    headers:
-      User-Agent: 'Mozilla/5.0 (X11; Linux x86_64)'
-      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
-      Accept-Language: 'en-US,en;q=0.5'
-
 ignorePatterns:
   - pattern: '^https://medium\.com/balancer-protocol/.*$'
   - pattern: '^https://medium\.com/immunefi/.*$'
+  - pattern: '^https://www\.npmjs\.com/.*$'


### PR DESCRIPTION
# Description

Like medium.com, npmjs.com often rejects bots with a 403, which causes linkspector to fail. It seemed like it was intermittent at first, but now it seems more persistent. So add this domain to the ignored list. (Just means we need to manually verify any new npmjs.com links we add.)

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
