### PR TITLE
docs: improve CHANGELOG Unreleased section formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
+
+Changes that have been merged but not yet released.
 
 ### Breaking changes
 


### PR DESCRIPTION
## Summary
Improves the formatting of the Unreleased section in CHANGELOG.md.

## Changes
- Add brackets around "Unreleased" for consistency with Keep a Changelog format
- Add description "Changes that have been merged but not yet released."

## Why This Is Needed
Follows the Keep a Changelog (https://keepachangelog.com) convention and provides clarity about what the Unreleased section contains.