### PR TITLE
Generalize factory template in the checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/deployment-preparation-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/deployment-preparation-template.md
@@ -9,7 +9,7 @@
 - [ ] `build-info` is updated with artifacts compiled at the specified commit
 - [ ] Artifacts are generated from `build-info`
 - [ ] New task has a working fork test <!-- This implies index and input scripts are correct -->
-- [ ] If this is a pool factory, a pool was deployed to testnet and successfully verified
+- [ ] If this is a factory, the product (e.g., pool) was deployed to testnet and successfully verified
 - [ ] Maxis have been informed of any required governance actions
 
 ## Deprecating old tasks checklist: <!-- Only if applicable -->


### PR DESCRIPTION
# Description

We have a template item to actually deploy to a testnet if the contract is a factory. Otherwise, the "live" deployment code is untested, and might fail during deployment and require changing code in the deployment PR.

It says "pool factory" now, but it actually applies to any factory. Oracles are also deployed with a factory (as are BPT wrappers, etc.) This PR generalizes the language to use the "design pattern" standard terms for any factory.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
