### PR TITLE
Add minimal age gate for yarn packages (1w)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,5 @@ nodeLinker: node-modules
 npmPublishAccess: public
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
+
+npmMinimalAgeGate: 10080


### PR DESCRIPTION
# Description

Whenever we update the lockfile, only bring in packages that have been released at least 1 week ago.
This should prevent (some?) supply chain attacks in case we're unlucky enough to update something while one of them is ongoing; they are usually discovered within hours / a day.

See https://github.com/yarnpkg/berry/issues/6899 for reference.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A