### PR TITLE
Hyperevm infrastructure

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,6 +8,8 @@ import 'hardhat-ignore-warnings';
 import 'tsconfig-paths/register';
 
 import './src/helpers/setupTests';
+import './scripts/hyperevm-big-blocks';
+import './scripts/hyperliquid-bridge';
 
 import { task } from 'hardhat/config';
 import { TASK_TEST } from 'hardhat/builtin-tasks/task-names';

--- a/scripts/hyperevm-big-blocks.ts
+++ b/scripts/hyperevm-big-blocks.ts
@@ -1,0 +1,95 @@
+// Hardhat task: toggle HyperEVM "big blocks" mode for the deployer EOA.
+//
+// HyperEVM produces small blocks (~1s, 2M gas) by default. Deployments whose
+// gas exceeds that limit are rejected with "exceeds block gas limit" until
+// the deployer EOA opts into big blocks (~60s, 30M gas) via a Hyperliquid
+// L1 user action. Flip on, deploy, flip off.
+//
+// Usage:
+//   npx hardhat hyperevm-big-blocks --enable  --network hyperevm
+//   npx hardhat hyperevm-big-blocks --disable --network hyperevm
+
+import { task } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+const HL_MAINNET_API = 'https://api.hyperliquid.xyz/exchange';
+
+task('hyperevm-big-blocks', 'Toggle HyperEVM big-blocks mode for the deployer EOA')
+  .addFlag('enable', 'Turn big blocks on')
+  .addFlag('disable', 'Turn big blocks off')
+  .setAction(async (args: { enable: boolean; disable: boolean }, hre: HardhatRuntimeEnvironment) => {
+    if (hre.network.name !== 'hyperevm') {
+      throw new Error(`Must be run with --network hyperevm (got ${hre.network.name})`);
+    }
+    if (args.enable === args.disable) {
+      throw new Error('Specify exactly one of --enable or --disable');
+    }
+    const usingBigBlocks = args.enable;
+
+    const [signer] = await hre.ethers.getSigners();
+    const address = await signer.getAddress();
+    console.log(`${usingBigBlocks ? 'Enabling' : 'Disabling'} big blocks for ${address}`);
+
+    const action = { type: 'evmUserModify', usingBigBlocks };
+    const nonce = Date.now();
+
+    // action_hash = keccak256(msgpack(action) || nonce_be_8 || vault_byte)
+    const actionBytes = msgpackEncodeEvmUserModify(usingBigBlocks);
+    const nonceBytes = Buffer.alloc(8);
+    nonceBytes.writeBigUInt64BE(BigInt(nonce));
+    const vaultBytes = Buffer.from([0x00]); // no vault
+    const connectionId = hre.ethers.keccak256(Buffer.concat([actionBytes, nonceBytes, vaultBytes]));
+
+    // EIP-712 over the "Agent" phantom domain. chainId is always 1337 for L1
+    // actions; source "a" = mainnet, "b" = testnet.
+    const domain = {
+      name: 'Exchange',
+      version: '1',
+      chainId: 1337,
+      verifyingContract: '0x0000000000000000000000000000000000000000',
+    };
+    const types = {
+      Agent: [
+        { name: 'source', type: 'string' },
+        { name: 'connectionId', type: 'bytes32' },
+      ],
+    };
+    const message = { source: 'a', connectionId };
+
+    const rawSig = await signer.signTypedData(domain, types, message);
+    const sig = hre.ethers.Signature.from(rawSig);
+
+    const payload = {
+      action,
+      nonce,
+      signature: { r: sig.r, s: sig.s, v: sig.v },
+      vaultAddress: null,
+    };
+
+    const res = await fetch(HL_MAINNET_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const body = await res.json();
+    if (body.status !== 'ok') {
+      throw new Error(`Hyperliquid API rejected the request: ${JSON.stringify(body)}`);
+    }
+    console.log(`OK — big blocks ${usingBigBlocks ? 'enabled' : 'disabled'} for ${address}`);
+    console.log(JSON.stringify(body, null, 2));
+  });
+
+// Inline msgpack for {type: "evmUserModify", usingBigBlocks: <bool>} so we
+// don't need a runtime msgpack dep for one fixed action shape.
+function msgpackEncodeEvmUserModify(usingBigBlocks: boolean): Buffer {
+  return Buffer.concat([
+    Buffer.from([0x82]), //                       fixmap, 2 entries
+    Buffer.from([0xa4]),
+    Buffer.from('type'), //  fixstr(4)
+    Buffer.from([0xad]),
+    Buffer.from('evmUserModify'), //   fixstr(13)
+    Buffer.from([0xae]),
+    Buffer.from('usingBigBlocks'), //  fixstr(14)
+    Buffer.from([usingBigBlocks ? 0xc3 : 0xc2]), // true / false
+  ]);
+}

--- a/scripts/hyperliquid-bridge.ts
+++ b/scripts/hyperliquid-bridge.ts
@@ -1,0 +1,79 @@
+// Hardhat task: deposit native USDC from the Arbitrum-side deployer into
+// Hyperliquid Bridge2, crediting the same address on HyperCore.
+//
+// Why: bypasses the Hyperliquid website's T&C / geo-block flow. The bridge
+// is just an ERC20 transfer to a fixed contract; the validators credit the
+// sender's address on HyperCore in under a minute.
+//
+// Prerequisite: the same deployer EOA must hold native USDC on Arbitrum
+// (NOT USDC.e — see the address constant below) and be configured as the
+// signer for the `arbitrum` network in ~/.hardhat/networks.json.
+//
+// Usage:
+//   npx hardhat hl-deposit --amount 5 --network arbitrum
+//
+// Bridge2 reference:
+//   https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/bridge2
+
+import { task } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+const BRIDGE2 = '0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7';
+const USDC_NATIVE_ARBITRUM = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+const USDC_E_ARBITRUM = '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'; // old bridged, NOT accepted
+const USDC_DECIMALS = 6;
+const MIN_USDC = 5n; // hard floor; anything less is lost per the docs
+
+const ERC20_ABI = [
+  'function balanceOf(address) view returns (uint256)',
+  'function transfer(address,uint256) returns (bool)',
+];
+
+task('hl-deposit', 'Deposit USDC to Hyperliquid Bridge2 on Arbitrum (creates the HyperCore account for the sender)')
+  .addParam('amount', 'USDC amount in whole units (minimum 5)')
+  .setAction(async (args: { amount: string }, hre: HardhatRuntimeEnvironment) => {
+    const chainId = Number((await hre.ethers.provider.getNetwork()).chainId);
+    if (chainId !== 42161) {
+      throw new Error(`Must be run with --network arbitrum (chainId 42161, got ${chainId})`);
+    }
+
+    const amountWhole = BigInt(args.amount);
+    if (amountWhole < MIN_USDC) {
+      throw new Error(
+        `Amount ${amountWhole} USDC is below the 5 USDC minimum. Anything less is lost forever per Hyperliquid docs.`
+      );
+    }
+    const amountUnits = amountWhole * 10n ** BigInt(USDC_DECIMALS);
+
+    const [signer] = await hre.ethers.getSigners();
+    const address = await signer.getAddress();
+    const usdc = new hre.ethers.Contract(USDC_NATIVE_ARBITRUM, ERC20_ABI, signer);
+    const balance: bigint = await usdc.balanceOf(address);
+
+    console.log(`From:    ${address}`);
+    console.log(`Bridge:  ${BRIDGE2}`);
+    console.log(`USDC:    ${USDC_NATIVE_ARBITRUM}  (native USDC on Arbitrum)`);
+    console.log(`Amount:  ${amountWhole} USDC  (${amountUnits} units)`);
+    console.log(`Balance: ${balance / 10n ** BigInt(USDC_DECIMALS)} USDC  (${balance} units)`);
+
+    if (balance < amountUnits) {
+      const usdcE = new hre.ethers.Contract(USDC_E_ARBITRUM, ERC20_ABI, signer);
+      const usdcEBal: bigint = await usdcE.balanceOf(address);
+      const hint =
+        usdcEBal > 0n
+          ? `\n\nYou hold ${
+              usdcEBal / 10n ** BigInt(USDC_DECIMALS)
+            } USDC.e at ${USDC_E_ARBITRUM} — that is the OLD bridged USDC and the Hyperliquid bridge does not accept it. Swap to native USDC (${USDC_NATIVE_ARBITRUM}) first.`
+          : '';
+      throw new Error(`Insufficient native USDC.${hint}`);
+    }
+
+    console.log(`\nSubmitting transfer...`);
+    const tx = await usdc.transfer(BRIDGE2, amountUnits);
+    console.log(`Tx: ${tx.hash}`);
+    const receipt = await tx.wait();
+    console.log(`Confirmed in block ${receipt?.blockNumber}`);
+    console.log(
+      `Credit on HyperCore typically lands in <1 minute. Verify the address shows up at https://app.hyperliquid.xyz before running hyperevm-big-blocks.`
+    );
+  });


### PR DESCRIPTION
# Description

Adds two Hardhat tasks to support deploying from a fresh deployer EOA on HyperEVM. Without these, a new account can't deploy because (a) the standard path to credit HyperCore goes through the Hyperliquid website's T&C / geo gate (a problem if you're from a heavily restricted country that's blocked everywhere: i.e., the US - and it detects VPNs), and (b) HyperEVM's default small blocks (~2M gas) reject deployment of larger contracts, which most of ours are. 

* hl-deposit (scripts/hyperliquid-bridge.ts)
    - Sends native USDC on Arbitrum to Hyperliquid's Bridge2 contract. Validators credit HyperCore for the sender's address in under a minute, no UI flow needed.
    - Enforces the 5 USDC minimum and refuses to run if you only hold USDC.e (the old bridged token, which is silently lost by the bridge).
    - Run as: `npx hardhat hl-deposit --amount 5 --network arbitrum`

* hyperevm-big-blocks (scripts/hyperevm-big-blocks.ts)
    - Toggles the deployer EOA's "big blocks" mode (~60s, 30M gas) via a Hyperliquid L1 evmUserModify action, which is necessary for any deploy whose constructor exceeds the default 2M-gas block limit.
    - Run as: `npx hardhat hyperevm-big-blocks --enable --network hyperevm` (and optionally --disable after).

Workflow
  
For a brand-new deployer EOA targeting HyperEVM:
1. Fund the EOA with native USDC on Arbitrum
2. hl-deposit to credit HyperCore
3. hyperevm-big-blocks --enable
4. Run the deployment task as usual against --network hyperevm
5. optionally set it back to small blocks if you use the account for other things: hyperevm-big-blocks --disable


## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
